### PR TITLE
fix file-input: fix "change" parameter binding

### DIFF
--- a/js/file-input/js/lumx.file_input_directive.js
+++ b/js/file-input/js/lumx.file_input_directive.js
@@ -10,7 +10,7 @@ angular.module('lumx.file-input', [])
             scope: {
                 label: '=',
                 value: '=',
-                change: '&change'
+                change: '&'
             },
             templateUrl: 'lumx.file_input.html',
             replace: true,


### PR DESCRIPTION
The "=" previously set binding doesn't work.
The "&change" fixes parameter binding on file_input_directive.

Also fix a jshint error on file_input_directive.
