### PR TITLE
fix scrollbar: Add Scrollbar Service

### DIFF
--- a/js/scrollbar/lumx.scrollbar_directive.js
+++ b/js/scrollbar/lumx.scrollbar_directive.js
@@ -3,6 +3,13 @@
 
 
 angular.module('lumx.scrollbar', [])
+    .service('LxScrollbarService', function()
+    {
+        this.update = function()
+        {
+            $(window).trigger('resize');
+        };
+    })
     .controller('LxScrollbarController', ['$scope', '$window', function($scope, $window)
     {
         var mousePosition,


### PR DESCRIPTION
The new Scrollbar Service is created to update, when it's necessary, the window resize event.
This update permit to apply the new scrollbar height when a ng-repeat is over.
