### PR TITLE
feat typography: line height and letter spacing

### DIFF
--- a/demo/css/lumx.css
+++ b/demo/css/lumx.css
@@ -421,27 +421,31 @@ html {
 .fs-caption {
   font-size: 12px;
   font-size: 0.75rem;
-  font-weight: 400; }
+  font-weight: 400;
+  line-height: 20px; }
 
 @media screen and (max-width: 1023px) {
-  .fs-body1,
-  .fs-body2 {
+  .fs-body-1,
+  .fs-body-2 {
     font-size: 14px;
     font-size: 0.875rem; } }
 @media screen and (min-width: 1024px) {
-  .fs-body1,
-  .fs-body2 {
+  .fs-body-1,
+  .fs-body-2 {
     font-size: 13px;
     font-size: 0.8125rem; } }
 
-.fs-body1 {
-  font-weight: 400; }
+.fs-body-1 {
+  font-weight: 400;
+  line-height: 20px; }
 
-.fs-body2 {
-  font-weight: 600; }
+.fs-body-2 {
+  font-weight: 600;
+  line-height: 24px; }
 
 .fs-subhead {
-  font-weight: 400; }
+  font-weight: 400;
+  line-height: 24px; }
   @media screen and (max-width: 1023px) {
     .fs-subhead {
       font-size: 16px;
@@ -454,32 +458,41 @@ html {
 .fs-title {
   font-size: 20px;
   font-size: 1.25rem;
-  font-weight: 600; }
+  font-weight: 600;
+  line-height: 28px; }
 
 .fs-headline {
   font-size: 24px;
   font-size: 1.5rem;
-  font-weight: 400; }
+  font-weight: 400;
+  line-height: 32px; }
 
-.fs-display1 {
+.fs-display-1 {
   font-size: 34px;
   font-size: 2.125rem;
-  font-weight: 400; }
+  font-weight: 400;
+  line-height: 40px; }
 
-.fs-display2 {
+.fs-display-2 {
   font-size: 45px;
   font-size: 2.8125rem;
-  font-weight: 400; }
+  font-weight: 400;
+  line-height: 48px;
+  letter-spacing: -1px; }
 
-.fs-display3 {
+.fs-display-3 {
   font-size: 56px;
   font-size: 3.5rem;
-  font-weight: 400; }
+  font-weight: 400;
+  line-height: 64px;
+  letter-spacing: -2px; }
 
-.fs-display4 {
+.fs-display-4 {
   font-size: 112px;
   font-size: 7rem;
-  font-weight: 300; }
+  font-weight: 300;
+  line-height: 128px;
+  letter-spacing: -5px; }
 
 .zero-whole {
   width: 0 !important; }
@@ -6175,9 +6188,9 @@ html {
   transition-delay: 0.1s; }
 .fab__actions--up .btn:nth-child(3),
 .fab__actions--left .btn:nth-child(3) {
-  -webkit-transition-delay: 0.06667s;
-  -moz-transition-delay: 0.06667s;
-  transition-delay: 0.06667s; }
+  -webkit-transition-delay: 0.0666666667s;
+  -moz-transition-delay: 0.0666666667s;
+  transition-delay: 0.0666666667s; }
 .fab__actions--up .btn:nth-child(4),
 .fab__actions--left .btn:nth-child(4) {
   -webkit-transition-delay: 0.05s;
@@ -6190,14 +6203,14 @@ html {
   transition-delay: 0.04s; }
 .fab__actions--up .btn:nth-child(6),
 .fab__actions--left .btn:nth-child(6) {
-  -webkit-transition-delay: 0.03333s;
-  -moz-transition-delay: 0.03333s;
-  transition-delay: 0.03333s; }
+  -webkit-transition-delay: 0.0333333333s;
+  -moz-transition-delay: 0.0333333333s;
+  transition-delay: 0.0333333333s; }
 .fab__actions--up .btn:nth-child(7),
 .fab__actions--left .btn:nth-child(7) {
-  -webkit-transition-delay: 0.02857s;
-  -moz-transition-delay: 0.02857s;
-  transition-delay: 0.02857s; }
+  -webkit-transition-delay: 0.0285714286s;
+  -moz-transition-delay: 0.0285714286s;
+  transition-delay: 0.0285714286s; }
 .fab__actions--up .btn:nth-child(8),
 .fab__actions--left .btn:nth-child(8) {
   -webkit-transition-delay: 0.025s;
@@ -6205,9 +6218,9 @@ html {
   transition-delay: 0.025s; }
 .fab__actions--up .btn:nth-child(9),
 .fab__actions--left .btn:nth-child(9) {
-  -webkit-transition-delay: 0.02222s;
-  -moz-transition-delay: 0.02222s;
-  transition-delay: 0.02222s; }
+  -webkit-transition-delay: 0.0222222222s;
+  -moz-transition-delay: 0.0222222222s;
+  transition-delay: 0.0222222222s; }
 .fab__actions--up .btn:nth-child(10),
 .fab__actions--left .btn:nth-child(10) {
   -webkit-transition-delay: 0.02s;
@@ -6450,8 +6463,8 @@ html {
     .grid__col1 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 6.17215%; }
+      margin-right: 2.3576515979%;
+      width: 6.1721527019%; }
       .grid__col1:last-child {
         margin-right: 0; } }
 
@@ -6466,8 +6479,8 @@ html {
     .grid__col2 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 14.70196%; }
+      margin-right: 2.3576515979%;
+      width: 14.7019570017%; }
       .grid__col2:last-child {
         margin-right: 0; } }
 
@@ -6482,8 +6495,8 @@ html {
     .grid__col3 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 23.23176%; }
+      margin-right: 2.3576515979%;
+      width: 23.2317613015%; }
       .grid__col3:last-child {
         margin-right: 0; } }
 
@@ -6498,8 +6511,8 @@ html {
     .grid__col4 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 31.76157%; }
+      margin-right: 2.3576515979%;
+      width: 31.7615656014%; }
       .grid__col4:last-child {
         margin-right: 0; } }
 
@@ -6514,8 +6527,8 @@ html {
     .grid__col5 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 40.29137%; }
+      margin-right: 2.3576515979%;
+      width: 40.2913699012%; }
       .grid__col5:last-child {
         margin-right: 0; } }
 
@@ -6530,8 +6543,8 @@ html {
     .grid__col6 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 48.82117%; }
+      margin-right: 2.3576515979%;
+      width: 48.821174201%; }
       .grid__col6:last-child {
         margin-right: 0; } }
 
@@ -6546,8 +6559,8 @@ html {
     .grid__col7 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 57.35098%; }
+      margin-right: 2.3576515979%;
+      width: 57.3509785009%; }
       .grid__col7:last-child {
         margin-right: 0; } }
 
@@ -6562,8 +6575,8 @@ html {
     .grid__col8 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 65.88078%; }
+      margin-right: 2.3576515979%;
+      width: 65.8807828007%; }
       .grid__col8:last-child {
         margin-right: 0; } }
 
@@ -6578,8 +6591,8 @@ html {
     .grid__col9 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 74.41059%; }
+      margin-right: 2.3576515979%;
+      width: 74.4105871005%; }
       .grid__col9:last-child {
         margin-right: 0; } }
 
@@ -6594,8 +6607,8 @@ html {
     .grid__col10 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 82.94039%; }
+      margin-right: 2.3576515979%;
+      width: 82.9403914003%; }
       .grid__col10:last-child {
         margin-right: 0; } }
 
@@ -6610,8 +6623,8 @@ html {
     .grid__col11 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
-      width: 91.4702%; }
+      margin-right: 2.3576515979%;
+      width: 91.4701957002%; }
       .grid__col11:last-child {
         margin-right: 0; } }
 
@@ -6626,7 +6639,7 @@ html {
     .grid__col12 {
       float: left;
       display: block;
-      margin-right: 2.35765%;
+      margin-right: 2.3576515979%;
       width: 100%; }
       .grid__col12:last-child {
         margin-right: 0; } }
@@ -9162,4 +9175,3 @@ body {
 
 .hljs-chunk {
   color: #aaa; }
-

--- a/demo/includes/css/typography/example.typography.html
+++ b/demo/includes/css/typography/example.typography.html
@@ -1,10 +1,10 @@
-<span class="fs-display4">Light 112sp</span><br />
-<span class="fs-display3">Regular 56sp</span><br />
-<span class="fs-display2">Regular 45sp</span><br />
-<span class="fs-display1">Regular 34sp</span><br />
+<span class="fs-display-4">Light 112sp</span><br />
+<span class="fs-display-3">Regular 56sp</span><br />
+<span class="fs-display-2">Regular 45sp</span><br />
+<span class="fs-display-1">Regular 34sp</span><br />
 <span class="fs-headline">Regular 24sp</span><br />
 <span class="fs-title">Medium 20sp</span><br />
 <span class="fs-subhead">Regular 16sp (Device), Regular 15sp (Desktop)</span><br />
-<span class="fs-body2">Medium 14sp (Device), Medium 13sp (Desktop)</span><br />
-<span class="fs-body1">Regular 14sp (Device), Regular 13sp (Desktop)</span><br />
+<span class="fs-body-2">Medium 14sp (Device), Medium 13sp (Desktop)</span><br />
+<span class="fs-body-1">Regular 14sp (Device), Regular 13sp (Desktop)</span><br />
 <span class="fs-caption">Regular 12sp</span>

--- a/scss/core/base/_base.typography.scss
+++ b/scss/core/base/_base.typography.scss
@@ -6,12 +6,13 @@
 %fs-caption {
     @include font-size(12px);
     font-weight: 400;
+    line-height: 20px;
 }
 
-.fs-body1,
-%fs-body1,
-.fs-body2,
-%fs-body2 {
+.fs-body-1,
+%fs-body-1,
+.fs-body-2,
+%fs-body-2 {
     @include media-query(portable) {
         @include font-size(14px);
     }
@@ -21,19 +22,22 @@
     }
 }
 
-.fs-body1,
-%fs-body1 {
+.fs-body-1,
+%fs-body-1 {
     font-weight: 400;
+    line-height: 20px;
 }
 
-.fs-body2,
-%fs-body2 {
+.fs-body-2,
+%fs-body-2 {
     font-weight: 600;
+    line-height: 24px;
 }
 
 .fs-subhead,
 %fs-subhead {
     font-weight: 400;
+    line-height: 24px;
 
     @include media-query(portable) {
         @include font-size(16px);
@@ -48,34 +52,43 @@
 %fs-title {
     @include font-size(20px);
     font-weight: 600;
+    line-height: 28px;
 }
 
 .fs-headline,
 %fs-headline {
     @include font-size(24px);
     font-weight: 400;
+    line-height: 32px;
 }
 
-.fs-display1,
-%fs-display1 {
+.fs-display-1,
+%fs-display-1 {
     @include font-size(34px);
     font-weight: 400;
+    line-height: 40px;
 }
 
-.fs-display2,
-%fs-display2 {
+.fs-display-2,
+%fs-display-2 {
     @include font-size(45px);
     font-weight: 400;
+    line-height: 48px;
+    letter-spacing: -1px;
 }
 
-.fs-display3,
-%fs-display3 {
+.fs-display-3,
+%fs-display-3 {
     @include font-size(56px);
     font-weight: 400;
+    line-height: 64px;
+    letter-spacing: -2px;
 }
 
-.fs-display4,
-%fs-display4 {
+.fs-display-4,
+%fs-display-4 {
     @include font-size(112px);
     font-weight: 300;
+    line-height: 128px;
+    letter-spacing: -5px;
 }


### PR DESCRIPTION
Typography helpers now have line height and letter spacing propertied
defined.

BROKEN: fs-display and fs-body variants now have a ‘-‘ to separate
number. For example, fs-display4 is now fs-display-4.
