### PR TITLE
feat scrollbar: Create getter & setter to watch scroll percentage

### DIFF
--- a/js/scrollbar/lumx.scrollbar_directive.js
+++ b/js/scrollbar/lumx.scrollbar_directive.js
@@ -218,8 +218,10 @@ angular.module('lumx.scrollbar', [])
             link: function(scope, element, attrs, ctrl)
             {
                 ctrl.init(element);
-                attrs.$observe('id', function (id) {
-                    if (angular.isDefined(id)) {
+                attrs.$observe('id', function (id)
+                {
+                    if (angular.isDefined(id))
+                    {
                         ctrl.setElementId(id);
                     }
                 });


### PR DESCRIPTION
Improve LumX Scrollbar by adding getter and setter on the service. 
If the id of the scroll element is set, we can $watch the scrollPercent of a specific scrollbar using the getter.
