### PR TITLE
fixing removing the tooltip when the tooltip is gone.

### DIFF
--- a/js/tooltip/lumx.tooltip_directive.js
+++ b/js/tooltip/lumx.tooltip_directive.js
@@ -123,7 +123,8 @@ angular.module('lumx.tooltip', [])
                         ctrl.init(element, attrs);
                     }
                 });
-                scope.$on('$destroy', function () {
+                scope.$on('$destroy', function () 
+                {
                     ctrl.hideTooltip();
                 });
             }


### PR DESCRIPTION
When the button or element that the tooltip is related is gone, for instance, via a ng-show or ng-if, the tooltip hangs in the screen. This fixed that.
