### PR TITLE
fix date-picker: watch the scope to handle async binding

### DIFF
--- a/js/date-picker/js/lumx.date_picker_directive.js
+++ b/js/date-picker/js/lumx.date_picker_directive.js
@@ -33,11 +33,9 @@ angular.module('lumx.date-picker', [])
         this.updateModel = function(val)
         {
             if (angular.isDefined(val)) {
-                $scope.model = val;
-
                 $scope.selectedDate = {
-                    date: moment($scope.model).locale(locale),
-                    formatted: moment($scope.model).locale(locale).format('LL')
+                    date: moment(val).locale(locale),
+                    formatted: moment(val).locale(locale).format('LL')
                 };
             }
         };


### PR DESCRIPTION
Before, async binding doesn't work.
Watching the "model" scope permit to update the date-picker correctly.
