### PR TITLE
change model to ngmodel

### DIFF
--- a/js/select/js/lumx.select_directive.js
+++ b/js/select/js/lumx.select_directive.js
@@ -289,7 +289,7 @@ angular.module('lumx.select', [])
 
                 if ($scope.change)
                 {
-                    $scope.change({ newValue: angular.copy(newConvertedValue), oldValue: angular.copy($scope.model) });
+                    $scope.change({ newValue: angular.copy(newConvertedValue), oldValue: angular.copy($scope.ngModel.$modelValue) });
                 }
                 $scope.ngModel.$setViewValue(angular.copy(newConvertedValue));
             });


### PR DESCRIPTION
Hi,since you have changed 'model' to 'ngModel' to make a two-way data binding, there must use $scope.ngModel.$modelValue instead of $scope.model