### PR TITLE
feat fab: click on fab and display flex

### DIFF
--- a/modules/fab/demo/includes/example.html
+++ b/modules/fab/demo/includes/example.html
@@ -7,9 +7,9 @@
         </button>
 
         <div class="fab__actions fab__actions--up">
-            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="left"><i class="mdi mdi-delete"></i></button><!--
-            --><button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="left"><i class="mdi mdi-package"></i></button><!--
-            --><button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="left"><i class="mdi mdi-pencil"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="left"><i class="mdi mdi-delete"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="left"><i class="mdi mdi-package"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="left"><i class="mdi mdi-pencil"></i></button>
         </div>
     </div>
 
@@ -21,9 +21,9 @@
         </button>
 
         <div class="fab__actions fab__actions--down">
-            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="right"><i class="mdi mdi-pencil"></i></button><!--
-            --><button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="right"><i class="mdi mdi-package"></i></button><!--
-            --><button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="right"><i class="mdi mdi-delete"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="right"><i class="mdi mdi-pencil"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="right"><i class="mdi mdi-package"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="right"><i class="mdi mdi-delete"></i></button>
         </div>
     </div>
 </div>
@@ -37,9 +37,9 @@
         </button>
 
         <div class="fab__actions fab__actions--left">
-            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="top"><i class="mdi mdi-delete"></i></button><!--
-            --><button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="top"><i class="mdi mdi-package"></i></button><!--
-            --><button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="top"><i class="mdi mdi-pencil"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="top"><i class="mdi mdi-delete"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="top"><i class="mdi mdi-package"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="top"><i class="mdi mdi-pencil"></i></button>
         </div>
     </div>
 
@@ -51,9 +51,9 @@
         </button>
 
         <div class="fab__actions fab__actions--right">
-            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="bottom"><i class="mdi mdi-pencil"></i></button><!--
-            --><button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="bottom"><i class="mdi mdi-package"></i></button><!--
-            --><button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="bottom"><i class="mdi mdi-delete"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="bottom"><i class="mdi mdi-pencil"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="bottom"><i class="mdi mdi-package"></i></button>
+            <button class="btn btn--l btn--black btn--fab" lx-ripple lx-tooltip="Lorem Ipsum" tooltip-position="bottom"><i class="mdi mdi-delete"></i></button>
         </div>
     </div>
 </div>

--- a/modules/fab/scss/_fab.scss
+++ b/modules/fab/scss/_fab.scss
@@ -10,7 +10,7 @@
 
     &:hover {
         .fab__primary .mdi {
-            &:first-child {
+            &:nth-of-type(1) {
                 @include transform(scale(0));
             }
 
@@ -80,11 +80,9 @@
 
     .fab__actions--left,
     .fab__actions--right {
-        white-space: nowrap;
-
-        .btn {
-            display: inline-block;
-        }
+        @include display(flex);
+        @include flex-direction(row);
+        @include flex-wrap(nowrap);
     }
 
     .fab__actions--up {


### PR DESCRIPTION
Before, one the FAB was clicked, then both icon appear on rollover. It
is now fixed.

Buttons that appear horizontally are now in a flex container : we don’t
need anymore <!— —> in the HTML to fix the inline-block space.