### PR TITLE
fix text-field, file-input: allow field labels to contain sanitized html

### DIFF
--- a/modules/file-input/views/file-input.html
+++ b/modules/file-input/views/file-input.html
@@ -1,5 +1,5 @@
 <div class="input-file">
-    <span class="input-file__label">{{ label }}</span>
+    <span class="input-file__label" ng-bind-html="label"></span>
     <span class="input-file__filename"></span>
     <input type="file">
 </div>

--- a/modules/select/views/select-selected.html
+++ b/modules/select/views/select-selected.html
@@ -1,12 +1,12 @@
 <div lx-dropdown-toggle>
-    <span class="lx-select__floating-label" ng-if="getSelectedElements().length !== 0 && floatingLabel">{{ placeholder }}</span>
+    <span class="lx-select__floating-label" ng-if="getSelectedElements().length !== 0 && floatingLabel" ng-bind-html="placeholder"></span>
 
     <div class="lx-select__selected"
          ng-class="{ 'lx-select__selected--is-unique': !multiple,
                      'lx-select__selected--is-multiple': multiple && getSelectedElements().length > 0,
                      'lx-select__selected--placeholder': getSelectedElements().length === 0 }"
          lx-ripple>
-        <span ng-if="getSelectedElements().length === 0">{{ placeholder }}</span>
+        <span ng-if="getSelectedElements().length === 0" ng-bind-html="placeholder"></span>
 
         <!-- ng-repeat is used to manage the initialization of the $select even for non-multiple selects -->
         <div ng-repeat="$selected in getSelectedElements()" ng-if="!multiple">

--- a/modules/text-field/views/text-field.html
+++ b/modules/text-field/views/text-field.html
@@ -7,9 +7,7 @@
                  'text-field--is-focused': data.focused,
                  'text-field--label-hidden': fixedLabel() && data.model,
                  'text-field--with-icon': icon && fixedLabel() }">
-    <label class="text-field__label">
-        {{ label }}
-    </label>
+    <label class="text-field__label" ng-bind-html="label"></label>
 
     <div class="text-field__icon" ng-if="icon && fixedLabel() ">
         <i class="mdi mdi-{{ icon }}"></i>


### PR DESCRIPTION
Sanitized markup should be allowed within the labels of form fields. Strong, u, em, etc. Currently the label is displayed with curly braces, which will not allow html to be rendered. Instead, use ng-bind-html on the label and span elements to properly render html.

Fix #169