### PR TITLE
fix date-picker: watch changes on model

### DIFF
--- a/modules/date-picker/js/date-picker_directive.js
+++ b/modules/date-picker/js/date-picker_directive.js
@@ -18,12 +18,12 @@ angular.module('lumx.date-picker', [])
             $datePicker = element.find('.lx-date-picker');
             $datePickerContainer = element;
 
-            self.build(locale);
+            self.build(locale, false);
         };
 
-        this.build = function(locale)
+        this.build = function(locale, isNewModel)
         {
-            if (locale === activeLocale)
+            if (locale === activeLocale && !isNewModel)
             {
                 return;
             }
@@ -213,7 +213,12 @@ angular.module('lumx.date-picker', [])
 
                 attrs.$observe('locale', function()
                 {
-                    ctrl.build(checkLocale(attrs.locale));
+                    ctrl.build(checkLocale(attrs.locale), false);
+                });
+
+                scope.$watch('model', function()
+                {
+                    ctrl.build(checkLocale(attrs.locale), true);
                 });
 
                 function checkLocale(locale)


### PR DESCRIPTION
Before, a change in the model value doesn't affect the datepicker. The watch set on this update handle the case when we update the model binded to the datepicker.