### PR TITLE
fix text-field: remove border on firefox in invalid text fields

### DIFF
--- a/modules/text-field/scss/_text-field.scss
+++ b/modules/text-field/scss/_text-field.scss
@@ -170,6 +170,7 @@
         cursor: text;
         background-color: transparent;
         @include appearance(none);
+        box-shadow: none;
 
         &:focus {
             outline: none;


### PR DESCRIPTION
Using Firefox when the text-field is invalid it has a border that it's from Firefox.
You can take a look here: http://ui.lumapps.com/directives/text-fields