### PR TITLE
feature gulp-server: add gulp-server to init app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ For example, using bash in a Unix system with the default path will need to edit
 4. Run ``./launch.sh`.
 5. Visit http://localhost:8888 in your browser, and voilà.
 
+#### or
+
+1. Run `npm install & bower install`.
+2. Run `gulp serve`.
+3. Visit http://localhost:8888 in your browser, and voilà.
 
 ## How to get help, contribute, or provide feedback
 

--- a/demo/includes/common/header.html
+++ b/demo/includes/common/header.html
@@ -10,13 +10,14 @@
             <img src="/images/logo/lumx-white.png">
         </a>
     </h1>
+    
 
     <nav class="main-nav main-nav--lap-and-up">
         <ul>
             <li><a href="/getting-started/installation" class="main-nav__link" lx-ripple="white">Getting started</a></li>
             <li><a href="/css/mixins" class="main-nav__link" lx-ripple="white">CSS</a></li>
             <li><a href="/directives/dropdowns" class="main-nav__link" lx-ripple="white">Directives</a></li>
-            <li><a href="/services/notifications" target="_self" class="main-nav__link" lx-ripple="white">Services</a></li>
+            <li><a href="/services/notifications" class="main-nav__link" lx-ripple="white">Services</a></li>
         </ul>
     </nav>
 
@@ -31,7 +32,7 @@
                     <li><a href="/getting-started/installation" class="dropdown-link">Getting started</a></li>
                     <li><a href="/css/mixins" class="dropdown-link">CSS</a></li>
                     <li><a href="/directives/dropdowns" class="dropdown-link">Directives</a></li>
-                    <li><a href="/services/notifications" target="_self" class="dropdown-link">Services</a></li>
+                    <li><a href="/services/notifications" class="dropdown-link">Services</a></li>
                 </ul>
             </lx-dropdown-menu>
         </lx-dropdown>

--- a/demo/includes/sidebar/sidebar-services.html
+++ b/demo/includes/sidebar/sidebar-services.html
@@ -4,7 +4,7 @@
     <div class="sidebar-menu">
         <ul>
             <li>
-                <a class="sidebar-menu__link" href="/services/notifications" target="_self" ng-click="Sidebar.toggleSidebar()">Notifications</a>
+                <a class="sidebar-menu__link" href="/services/notifications" ng-click="Sidebar.toggleSidebar()">Notifications</a>
             </li>
             <li>
                 <a class="sidebar-menu__link" href="/services/progress" ng-click="Sidebar.toggleSidebar()">Progress</a>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,8 +2,7 @@ var gulp = require('gulp'),
     minimist = require('minimist'),
     summary = require('jshint-summary'),
     del = require('del'),
-    plugins = require('gulp-load-plugins')(),
-    connect = require('gulp-connect');
+    plugins = require('gulp-load-plugins')();
 
 var paths = {
     js: [
@@ -49,22 +48,6 @@ function watcherWithCache(name, src, tasks)
             plugins.remember.forget(name, event.path);
         }
     });
-}
-
-function registerWatchers() {
-    watcherWithCache('lint', paths.js, ['lint']);
-    watcherWithCache('scss', [paths.scss, 'demo/scss/**/*.scss'], ['scss']);
-    watcherWithCache('demo', paths.demo, ['demo']);
-    watcherWithCache('examples', paths.examples, ['examples']);
-    watcherWithCache('libs', paths.libs, ['libs']);
-    watcherWithCache('tpl:dropdown', 'modules/dropdown/views/*.html', ['tpl:dropdown']);
-    watcherWithCache('tpl:file-input', 'modules/file-input/views/*.html', ['tpl:file-input']);
-    watcherWithCache('tpl:text-field', 'modules/text-field/views/*.html', ['tpl:text-field']);
-    watcherWithCache('tpl:search-filter', 'modules/search-filter/views/*.html', ['tpl:search-filter']);
-    watcherWithCache('tpl:select', 'modules/select/views/*.html', ['tpl:select']);
-    watcherWithCache('tpl:tabs', 'modules/tabs/views/*.html', ['tpl:tabs']);
-    watcherWithCache('tpl:date-picker', 'modules/date-picker/views/*.html', ['tpl:date-picker']);
-    watcherWithCache('tpl:progress', 'modules/progress/views/*.html', ['tpl:progress']);
 }
 
 var knownOptions =
@@ -284,18 +267,27 @@ gulp.task('dist:scripts', ['tpl:dropdown', 'tpl:file-input', 'tpl:text-field', '
         .pipe(gulp.dest('dist'));
 });
 
-gulp.task('connect', function() {
-    connect.server({
+gulp.task('serve', ['watch'], function() {
+    return plugins.connect.server({
         root: 'build'
     });
 });
 
-gulp.task('serve', ['build', 'connect'], function () {
-    registerWatchers();
-});
-
-gulp.task('watch', ['build'], function() {
-    registerWatchers();
+gulp.task('watch', ['build'], function()
+{
+    watcherWithCache('lint', paths.js, ['lint']);
+    watcherWithCache('scss', [paths.scss, 'demo/scss/**/*.scss'], ['scss']);
+    watcherWithCache('demo', paths.demo, ['demo']);
+    watcherWithCache('examples', paths.examples, ['examples']);
+    watcherWithCache('libs', paths.libs, ['libs']);
+    watcherWithCache('tpl:dropdown', 'modules/dropdown/views/*.html', ['tpl:dropdown']);
+    watcherWithCache('tpl:file-input', 'modules/file-input/views/*.html', ['tpl:file-input']);
+    watcherWithCache('tpl:text-field', 'modules/text-field/views/*.html', ['tpl:text-field']);
+    watcherWithCache('tpl:search-filter', 'modules/search-filter/views/*.html', ['tpl:search-filter']);
+    watcherWithCache('tpl:select', 'modules/select/views/*.html', ['tpl:select']);
+    watcherWithCache('tpl:tabs', 'modules/tabs/views/*.html', ['tpl:tabs']);
+    watcherWithCache('tpl:date-picker', 'modules/date-picker/views/*.html', ['tpl:date-picker']);
+    watcherWithCache('tpl:progress', 'modules/progress/views/*.html', ['tpl:progress']);
 });
 
 gulp.task('clean', ['clean:build', 'clean:dist']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,8 @@ var gulp = require('gulp'),
     minimist = require('minimist'),
     summary = require('jshint-summary'),
     del = require('del'),
-    plugins = require('gulp-load-plugins')();
+    plugins = require('gulp-load-plugins')(),
+    connect = require('gulp-connect');
 
 var paths = {
     js: [
@@ -48,6 +49,22 @@ function watcherWithCache(name, src, tasks)
             plugins.remember.forget(name, event.path);
         }
     });
+}
+
+function registerWatchers() {
+    watcherWithCache('lint', paths.js, ['lint']);
+    watcherWithCache('scss', [paths.scss, 'demo/scss/**/*.scss'], ['scss']);
+    watcherWithCache('demo', paths.demo, ['demo']);
+    watcherWithCache('examples', paths.examples, ['examples']);
+    watcherWithCache('libs', paths.libs, ['libs']);
+    watcherWithCache('tpl:dropdown', 'modules/dropdown/views/*.html', ['tpl:dropdown']);
+    watcherWithCache('tpl:file-input', 'modules/file-input/views/*.html', ['tpl:file-input']);
+    watcherWithCache('tpl:text-field', 'modules/text-field/views/*.html', ['tpl:text-field']);
+    watcherWithCache('tpl:search-filter', 'modules/search-filter/views/*.html', ['tpl:search-filter']);
+    watcherWithCache('tpl:select', 'modules/select/views/*.html', ['tpl:select']);
+    watcherWithCache('tpl:tabs', 'modules/tabs/views/*.html', ['tpl:tabs']);
+    watcherWithCache('tpl:date-picker', 'modules/date-picker/views/*.html', ['tpl:date-picker']);
+    watcherWithCache('tpl:progress', 'modules/progress/views/*.html', ['tpl:progress']);
 }
 
 var knownOptions =
@@ -267,21 +284,18 @@ gulp.task('dist:scripts', ['tpl:dropdown', 'tpl:file-input', 'tpl:text-field', '
         .pipe(gulp.dest('dist'));
 });
 
-gulp.task('watch', ['build'], function()
-{
-    watcherWithCache('lint', paths.js, ['lint']);
-    watcherWithCache('scss', [paths.scss, 'demo/scss/**/*.scss'], ['scss']);
-    watcherWithCache('demo', paths.demo, ['demo']);
-    watcherWithCache('examples', paths.examples, ['examples']);
-    watcherWithCache('libs', paths.libs, ['libs']);
-    watcherWithCache('tpl:dropdown', 'modules/dropdown/views/*.html', ['tpl:dropdown']);
-    watcherWithCache('tpl:file-input', 'modules/file-input/views/*.html', ['tpl:file-input']);
-    watcherWithCache('tpl:text-field', 'modules/text-field/views/*.html', ['tpl:text-field']);
-    watcherWithCache('tpl:search-filter', 'modules/search-filter/views/*.html', ['tpl:search-filter']);
-    watcherWithCache('tpl:select', 'modules/select/views/*.html', ['tpl:select']);
-    watcherWithCache('tpl:tabs', 'modules/tabs/views/*.html', ['tpl:tabs']);
-    watcherWithCache('tpl:date-picker', 'modules/date-picker/views/*.html', ['tpl:date-picker']);
-    watcherWithCache('tpl:progress', 'modules/progress/views/*.html', ['tpl:progress']);
+gulp.task('connect', function() {
+    connect.server({
+        root: 'build'
+    });
+});
+
+gulp.task('serve', ['build', 'connect'], function () {
+    registerWatchers();
+});
+
+gulp.task('watch', ['build'], function() {
+    registerWatchers();
 });
 
 gulp.task('clean', ['clean:build', 'clean:dist']);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "gulp": "^3.8.10",
     "gulp-cached": "^1.0.1",
     "gulp-concat": "^2.3.4",
+    "gulp-connect": "^2.2.0",
     "gulp-insert": "^0.4.0",
     "gulp-jshint": "^1.8.4",
     "gulp-load-plugins": "^0.7.0",


### PR DESCRIPTION
Hi!
In the header.html, the last link "Services" was reloading the whole app again, because of that target="_self".

I added a new possibility to run the app.
Just run 'gulp serve', without having to install Python SDK of Google App Engine.
Open this url: http://localhost:8080 and it's running