### PR TITLE
added an option to not overwrite the position styles on the menu

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -111,6 +111,11 @@ angular.module('lumx.dropdown', [])
 
         function setDropdownMenuCss()
         {
+            if ($scope.direction === 'none')
+            {
+                return;
+            }
+
             var dropdownMenuWidth = dropdownMenu.outerWidth();
             dropdownMenuHeight = dropdownMenu.outerHeight();
             var origin = {


### PR DESCRIPTION
If you have a dropdown menu that you want rendered in a specific place (not relative to the cursor location), you can now add a 'direction="none"' attribute to the menu and the menu's position won't get overwritten in the "setDropdownMenuCss" method.