### PR TITLE
option to show both icons and tab headers at once

### DIFF
--- a/modules/tabs/js/tabs_directive.js
+++ b/modules/tabs/js/tabs_directive.js
@@ -186,7 +186,8 @@ angular.module('lumx.tabs', [])
                 indicator: '@',
                 noDivider: '@',
                 zDepth: '@',
-                layout: '@'
+                layout: '@',
+                showIconAndHeading: '@'
             },
             link: function(scope, element, attrs, ctrl)
             {

--- a/modules/tabs/views/tabs.html
+++ b/modules/tabs/views/tabs.html
@@ -8,7 +8,7 @@
                ng-click="setActiveTab($index)"
                lx-ripple="{{ indicator }}">
                <span ng-if="tab.icon !== undefined"><i class="mdi mdi-{{ tab.icon }}"></i></span>
-               <span ng-if="tab.icon === undefined">{{ tab.heading }}</i></span>
+               <span ng-if="tab.icon === undefined || showIconAndHeading">{{ tab.heading }}</i></span>
             </a>
         </li>
     </ul>


### PR DESCRIPTION
Sometimes a design requires both text and icons to be shown at a certain resolution, and then at a lower resolution the tabs should only show the icons.  This adds support to the directive for such a behavior, if the user wants to display both tab icons and header text at the same time.