### PR TITLE
added iconPrefix attribute to lxTabs directive

### DIFF
--- a/modules/tabs/js/tabs_directive.js
+++ b/modules/tabs/js/tabs_directive.js
@@ -186,7 +186,8 @@ angular.module('lumx.tabs', [])
                 indicator: '@',
                 noDivider: '@',
                 zDepth: '@',
-                layout: '@'
+                layout: '@',
+                iconPrefix: '@'
             },
             link: function(scope, element, attrs, ctrl)
             {
@@ -215,6 +216,11 @@ angular.module('lumx.tabs', [])
                 if (angular.isUndefined(scope.layout))
                 {
                     scope.layout = 'full';
+                }
+
+                if (angular.isUndefined(scope.iconPrefix))
+                {
+                    scope.iconPrefix = 'mdi mdi-';
                 }
             }
         };

--- a/modules/tabs/views/tabs.html
+++ b/modules/tabs/views/tabs.html
@@ -7,7 +7,7 @@
                ng-class="{ 'tabs-link--is-active': $index === activeTab }"
                ng-click="setActiveTab($index)"
                lx-ripple="{{ indicator }}">
-               <span ng-if="tab.icon !== undefined"><i class="mdi mdi-{{ tab.icon }}"></i></span>
+               <span ng-if="tab.icon !== undefined"><i class="{{iconPrefix}}{{ tab.icon }}"></i></span>
                <span ng-if="tab.icon === undefined">{{ tab.heading }}</i></span>
             </a>
         </li>


### PR DESCRIPTION
Adds another attribute to the lxTabs directive which allows for easily changing the tab prefix, instead of locking the user in to `mdi` icons.  The user may now specify a custom font prefix (eg. `fa fa-` for FontAwesome or `myico myico-` for a custom set of icons).