### PR TITLE
feat file-input: Allow clear

### DIFF
--- a/modules/file-input/demo/includes/example.html
+++ b/modules/file-input/demo/includes/example.html
@@ -4,8 +4,6 @@
     </div>
 
     <div flex-item>
-        <lx-text-field label="First name">
-            <input type="text" ng-model="textFields.firstName">
-        </lx-text-field>
+        <lx-file-input label="Browse" allow-clear="true"></lx-file-input>
     </div>
 </div>

--- a/modules/file-input/js/file-input_directive.js
+++ b/modules/file-input/js/file-input_directive.js
@@ -62,6 +62,7 @@ angular.module('lumx.file-input', [])
                     element.removeClass('input-file--is-active');
                     scope.value = null;
                     scope.model = undefined;
+                    $input.val(null);
                 };
 
                 scope.$watch('value', function(value)

--- a/modules/file-input/js/file-input_directive.js
+++ b/modules/file-input/js/file-input_directive.js
@@ -50,10 +50,6 @@ angular.module('lumx.file-input', [])
 
                         element.addClass('input-file--is-active');
                     }
-                    else
-                    {
-                        scope.clear();
-                    }
                 }
 
                 scope.clear = function()

--- a/modules/file-input/js/file-input_directive.js
+++ b/modules/file-input/js/file-input_directive.js
@@ -10,7 +10,8 @@ angular.module('lumx.file-input', [])
             scope: {
                 label: '@',
                 value: '=',
-                change: '&'
+                change: '&',
+                allowClear: '='
             },
             templateUrl: 'file-input.html',
             replace: true,
@@ -49,12 +50,29 @@ angular.module('lumx.file-input', [])
 
                         element.addClass('input-file--is-active');
                     }
+                    else
+                    {
+                        scope.clear();
+                    }
                 }
+
+                scope.clear = function()
+                {
+                    if (angular.isDefined(scope.change))
+                    {
+                        scope.change({e: $input[0].files[0], newValue: null, oldValue: $fileName.text()});
+                    }
+                    $fileName.text(null);
+                    element.removeClass('input-file--is-active');
+                    scope.value = null;
+                    scope.model = undefined;
+                };
 
                 scope.$watch('value', function(value)
                 {
                     setFileName(value);
                 });
+
             }
         };
     }]);

--- a/modules/file-input/scss/_file-input.scss
+++ b/modules/file-input/scss/_file-input.scss
@@ -7,6 +7,7 @@
     position: relative;
     padding-top: $base-spacing-unit * 4;
     padding-bottom: $base-spacing-unit;
+    overflow: hidden;
 
     &:before,
     &:after {
@@ -38,6 +39,11 @@
     .input-file__filename {
         opacity: 1;
     }
+
+    .input-file__clear {
+        @include transform(translateX(0));
+        z-index: 1;
+    }
 }
 
 .input-file--is-focused {
@@ -49,7 +55,13 @@
         color: $blue-500;
     }
 }
-    
+
+    // Input file container
+    .input-file__container {
+        position: relative;
+        padding: 0 $size-l 0 0;
+    }
+
     // Input file label
     .input-file__label {
         display: block;
@@ -81,4 +93,20 @@
         @include size(100% 32px);
         opacity: 0;
         cursor: pointer;
+    }
+
+    // Input file Clear
+    .input-file__clear {
+        @include position(absolute, 0 0 null null);
+        text-align: center;
+        cursor: pointer;
+        line-height: 32px;
+        @include transform(translateX($size-l));
+        @include transition-property(transform);
+        @include transition-duration(0.4s);
+        @include transition-timing-function($ease-out-quint);
+
+        &:hover {
+            color: $red-500;
+        }
     }

--- a/modules/file-input/views/file-input.html
+++ b/modules/file-input/views/file-input.html
@@ -1,5 +1,8 @@
 <div class="input-file">
-    <span class="input-file__label" ng-bind-html="label"></span>
-    <span class="input-file__filename"></span>
+    <div ng-class="::{'input-file__container': allowClear}">
+        <span class="input-file__filename"></span>
+        <span ng-if="::allowClear" class="input-file__clear" ng-click="clear()"><i class="mdi mdi-close-circle"></i></span>
+    </div>
     <input type="file">
+    <span class="input-file__label" ng-bind-html="label"></span>
 </div>


### PR DESCRIPTION
When input-file is pre-populated, we cannot clear it.
We added a allow-clear attribute on the directive to display a clear button (as in select or search)
The clear button triggers the clear() method and call the change method passed as an attribute of the directive.