### PR TITLE
Prevent going trought closing function

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -284,7 +284,7 @@ angular.module('lumx.dropdown', [])
                 unlinkList();
                 LxDropdownService.open($scope);
             }
-            else
+            else if ($scope.isDropped) {
             {
                 linkList();
                 LxDropdownService.close($scope);


### PR DESCRIPTION
When you first load your template, the dropdown is not dropped (isDropped and isOpened are both false).

you then go throught the following fonctions:

```
linkList();
LxDropdownService.close($scope);
```

which are useless to call at this point.