### PR TITLE
Fix issue #247 fix year date selection for multiple datepickers

### DIFF
--- a/modules/date-picker/js/date-picker_directive.js
+++ b/modules/date-picker/js/date-picker_directive.js
@@ -145,8 +145,8 @@ angular.module('lumx.date-picker', [])
 
         $scope.displayYearSelection = function()
         {
-            var calendarHeight = angular.element('.lx-date-picker__calendar').outerHeight(),
-                $yearSelector = angular.element('.lx-date-picker__year-selector');
+            var calendarHeight = $datePicker.children('.lx-date-picker__calendar').outerHeight(),
+                $yearSelector = $datePicker.children('.lx-date-picker__year-selector');
 
             $yearSelector.css({ height: calendarHeight });
 


### PR DESCRIPTION
The issue happens when there are multiple datepickers on the same page. The selector is class based, the wrong year selector is returned, which has no height and thus nothing is shown.

This PR fixes the issue, scoping the selector to the parent datepicker element.