### PR TITLE
Fix lx-select in Angular 1.4.0

### DIFF
--- a/modules/select/js/select_directive.js
+++ b/modules/select/js/select_directive.js
@@ -3,6 +3,15 @@
 
 
 angular.module('lumx.select', [])
+    .filter('filterChoices', ['$filter', function($filter) {
+      return function(choices, expression, comparator) {
+        if (!angular.isArray(choices)) {
+          return choices;
+        }
+
+        return $filter('filter')(choices, expression, comparator);
+      };
+    }])
     .controller('LxSelectController', ['$scope', '$compile', '$filter', '$interpolate', '$sce', '$timeout',
                                        function($scope, $compile, $filter, $interpolate, $sce, $timeout)
     {
@@ -101,7 +110,7 @@ angular.module('lumx.select', [])
 
         function hasNoResults()
         {
-            return angular.isUndefined($scope.choices()) || $filter('filter')($scope.choices(), $scope.data.filter).length === 0;
+            return angular.isUndefined($scope.choices()) || $filter('filterChoices')($scope.choices(), $scope.data.filter).length === 0;
         }
 
         function filterNeeded()

--- a/modules/select/views/select-choices.html
+++ b/modules/select/views/select-choices.html
@@ -17,7 +17,7 @@
             <span ng-if="hasNoResults() && !filterNeeded()">No results!</span>
         </li>
 
-        <li ng-repeat="$choice in choices() | filter:data.filter" ng-if="isChoicesVisible() && isChoicesArray()">
+        <li ng-repeat="$choice in choices() | filterChoices:data.filter" ng-if="isChoicesVisible() && isChoicesArray()">
             <a class="lx-select__choice dropdown-link"
                ng-class="{ 'lx-select__choice--is-multiple': multiple,
                            'lx-select__choice--is-selected': isSelected($choice) }"
@@ -29,7 +29,7 @@
             <span class="dropdown-link dropdown-link--is-header" ng-bind-html="trust($subheader)"></span>
         </li>
 
-        <li ng-repeat-end ng-repeat="$choice in children | filter:data.filter" ng-if="isChoicesVisible() && !isChoicesArray()">
+        <li ng-repeat-end ng-repeat="$choice in children | filterChoices:data.filter" ng-if="isChoicesVisible() && !isChoicesArray()">
             <a class="lx-select__choice dropdown-link"
                ng-class="{ 'lx-select__choice--is-multiple': multiple,
                            'lx-select__choice--is-selected': isSelected($choice) }"


### PR DESCRIPTION
Angular 1.4.0 changes the behaviour of the "filter" filter.
If it does not receive an array an error is thrown.

Relevant commit:
https://github.com/angular/angular.js/commit/cea8e75144e6910b806b63a6ec2a6d118316fddd#diff-ea6dc49a7f9836eb439e02fd27e86217

I've created a custom filter, which handles non array arguments and falls back to the standard one if arguments are valid.