### PR TITLE
Fix build command in guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ git checkout -b my-fix-branch master
 * Build your changes locally.
 
 ```shell
-bower dist
+gulp dist
 ```
 
 * Push your branch to GitHub:


### PR DESCRIPTION
Proably a type, should be gulp dist and not bower dist.