### PR TITLE
Tooltip existence check during $destroy event

### DIFF
--- a/modules/tooltip/js/tooltip_directive.js
+++ b/modules/tooltip/js/tooltip_directive.js
@@ -111,7 +111,9 @@ angular.module('lumx.tooltip', [])
 
         $scope.$on('$destroy', function(scope)
         {
-            tooltip.remove();
+            if (tooltip) {
+                tooltip.remove();
+            }
         });
     }])
     .directive('lxTooltip', function()


### PR DESCRIPTION
added check on $destroy event of tooltip for existence of 'tooltip' variable as there are use cases when it is not initialized and javascript displays unwanted errors

mentioned in issue #291