### PR TITLE
feat tabs: Allow to define the heading background and font color

### DIFF
--- a/modules/tabs/demo/includes/example.html
+++ b/modules/tabs/demo/includes/example.html
@@ -35,11 +35,11 @@
 
 <div class="card mt++">
     <lx-tabs indicator="green-200" active-tab="1" layout="inline">
-        <lx-tab heading="Lorem">
+        <lx-tab heading="Lorem" heading-tc="red-500">
             <p class="p+">Lorem Ipsum Content 1</p>
         </lx-tab>
 
-        <lx-tab heading="Lorem Ipsum">
+        <lx-tab heading="Lorem Ipsum" heading-bgc="pink-500" heading-tc="white">
             <p class="p+">Lorem Ipsum Content 2</p>
         </lx-tab>
 

--- a/modules/tabs/js/tabs_directive.js
+++ b/modules/tabs/js/tabs_directive.js
@@ -463,6 +463,16 @@ angular.module('lumx.tabs', [])
                     scope.lxTabHeading = newValue;
                 });
 
+                attrs.$observe('headingBgc', function(newValue)
+                {
+                    scope.lxTabHeadingBgc = newValue;
+                });
+
+                attrs.$observe('headingTc', function(newValue)
+                {
+                    scope.lxTabHeadingTc = newValue;
+                });
+
                 attrs.$observe('icon', function(newValue)
                 {
                     scope.lxTabIcon = newValue;

--- a/modules/tabs/scss/_tabs.scss
+++ b/modules/tabs/scss/_tabs.scss
@@ -42,7 +42,7 @@
         color: $white-1;
     }
 
-    .tabs-link {
+    .tabs__links li {
         color: $white-2;
     }
 
@@ -61,7 +61,7 @@
         color: $black-1;
     }
 
-    .tabs-link {
+    .tabs__links li {
         color: $black-2;
     }
 }
@@ -106,7 +106,7 @@
 .tabs--no-divider:after {
     display: none;
 }
-    
+
     // Tabs links
     .tabs__links {
         position: relative;

--- a/modules/tabs/views/tabs.html
+++ b/modules/tabs/views/tabs.html
@@ -10,7 +10,8 @@
 
     <ul class="tabs__links bgc-{{ lxTabsLinksBgc }} z-depth{{ lxTabsZDepth }}"
         ng-class="{'tabs__pagination-padding': lxTabsIsPaginationActive()}">
-        <li ng-repeat="tab in lxTabsGetTabs() track by $index">
+        <li ng-repeat="tab in lxTabsGetTabs() track by $index"
+            ng-class="{'bgc-{{ tab.lxTabHeadingBgc }}': tab.lxTabHeadingBgc, 'tc-{{ tab.lxTabHeadingTc }}': tab.lxTabHeadingTc}">
             <a lx-tab-link
                class="tabs-link"
                ng-class="{ 'tabs-link--is-active': $index === lxTabsActiveTab }"


### PR DESCRIPTION
This PR adds two params to the tabs : "heading-bgc" and "heading-tc".

Like that we can change the tabs background and font color for all tabs or for each.