### PR TITLE
fix dialog: unbind scroll event on close

### DIFF
--- a/modules/dialog/js/dialog_directive.js
+++ b/modules/dialog/js/dialog_directive.js
@@ -72,6 +72,8 @@ angular.module('lumx.dialog', [])
 
         this.close = function(dialogId)
         {
+            angular.element('.dialog__scrollable').off('scroll', checkScrollEnd);
+
             activeDialogId = undefined;
             $rootScope.$broadcast('lx-dialog__close-start', dialogId);
             if (resizeDebounce)


### PR DESCRIPTION
This will avoid to call the checkScrollEnd function leading to an
error because of the activeDialogId beeing undefined.
This fix can replace the previous one on this file (see PR #322)