### PR TITLE
feat: escape to close dialog/dropdown/confirm/alert

### DIFF
--- a/core/js/lumx.js
+++ b/core/js/lumx.js
@@ -2,7 +2,8 @@
 
 angular.module('lumx.utils', [
     'lumx.utils.transclude',
-    'lumx.utils.transclude-replace'
+    'lumx.utils.transclude-replace',
+    'lumx.utils.event-scheduler'
 ]);
 
 angular.module('lumx', [

--- a/core/js/utils/event-scheduler_service.js
+++ b/core/js/utils/event-scheduler_service.js
@@ -1,0 +1,103 @@
+/* global angular */
+/* global window */
+'use strict'; // jshint ignore:line
+
+
+angular.module('lumx.utils.event-scheduler', [])
+    .service('LxEventSchedulerService', ['$document', function($document)
+    {
+        var handlers = {},
+            schedule = {};
+
+        function generateUUID()
+        {
+            var d = new Date().getTime();
+
+            var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c)
+            {
+                var r = (d + Math.random() * 16) % 16 | 0;
+                d = Math.floor(d / 16);
+                return (c == 'x' ? r : (r & 0x3 | 0x8))
+                    .toString(16);
+            });
+
+            return uuid.toUpperCase();
+        }
+
+        function handle(event)
+        {
+            var scheduler = schedule[event.type];
+
+            if (angular.isDefined(scheduler))
+            {
+                for (var i = 0, length = scheduler.length; i < length; i++)
+                {
+                    var handler = scheduler[i];
+
+                    if (angular.isDefined(handler) && angular.isDefined(handler.callback) && angular.isFunction(handler.callback))
+                    {
+                        handler.callback(event);
+
+                        if (event.isPropagationStopped())
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        function register(eventName, callback)
+        {
+            var handler = {
+                eventName: eventName,
+                callback: callback
+            };
+
+            var id = generateUUID();
+            handlers[id] = handler;
+
+            if (angular.isUndefined(schedule[eventName]))
+            {
+                schedule[eventName] = [];
+
+                $document.on(eventName, handle);
+            }
+            schedule[eventName].unshift(handlers[id]);
+
+            return id;
+        }
+
+        function unregister(id)
+        {
+            var found = false;
+            var handler = handlers[id];
+
+            if (angular.isDefined(handler) && angular.isDefined(schedule[handler.eventName]))
+            {
+                var index = schedule[handler.eventName].indexOf(handler);
+
+                if (angular.isDefined(index) && index > -1)
+                {
+                    schedule[handler.eventName].splice(index, 1);
+
+                    delete handlers[id];
+                    found = true;
+                }
+
+                if (schedule[handler.eventName].length === 0)
+                {
+                    delete schedule[handler.eventName];
+
+                    $document.off(handler.eventName, handle);
+                }
+            }
+
+            return found;
+        }
+
+        return {
+            register: register,
+            unregister: unregister
+        };
+    }]);

--- a/demo/index.html
+++ b/demo/index.html
@@ -86,6 +86,7 @@
     <!-- Utils -->
     <script src="/js/utils/transclude_directive.js"></script>
     <script src="/js/utils/transclude-replace_directive.js"></script>
+    <script src="/js/utils/event-scheduler_service.js"></script>
 
     <!-- App -->
     <script src="/app.js"></script>

--- a/modules/dialog/js/dialog_directive.js
+++ b/modules/dialog/js/dialog_directive.js
@@ -271,6 +271,11 @@ angular.module('lumx.dialog', ['lumx.utils.event-scheduler'])
                     scope.lxDialogAutoClose = newValue;
                 });
 
+                attrs.$observe('escapeClose', function(newValue)
+                {
+                    scope.lxDialogEscapeClose = newValue;
+                });
+
                 attrs.$observe('onclose', function(newValue)
                 {
                     scope.lxDialogOnclose = function()

--- a/modules/notification/js/notification_service.js
+++ b/modules/notification/js/notification_service.js
@@ -3,15 +3,16 @@
 'use strict'; // jshint ignore:line
 
 
-angular.module('lumx.notification', [])
-    .service('LxNotificationService', ['$injector', '$rootScope', '$timeout' , function($injector, $rootScope, $timeout)
+angular.module('lumx.notification', ['lumx.utils.event-scheduler'])
+    .service('LxNotificationService', ['$injector', '$rootScope', '$timeout', '$document', 'LxEventSchedulerService', function($injector, $rootScope, $timeout, $document, LxEventSchedulerService)
     {
         //
         // PRIVATE MEMBERS
         //
         var notificationList = [],
             dialogFilter,
-            dialog;
+            dialog,
+            idEventScheduler;
 
         //
         // NOTIFICATION
@@ -28,15 +29,15 @@ angular.module('lumx.notification', [])
         {
             var newNotifIndex = notificationList.length - 1;
             notificationList[newNotifIndex].height = getElementHeight(notificationList[newNotifIndex].elem[0]);
-            
+
             var upOffset = 0;
-            
+
             for (var idx = newNotifIndex; idx >= 0; idx--)
             {
                 if (notificationList.length > 1 && idx !== newNotifIndex)
                 {
                     upOffset = 24 + notificationList[newNotifIndex].height;
-                    
+
                     notificationList[idx].margin += upOffset;
                     notificationList[idx].elem.css('marginBottom', notificationList[idx].margin + 'px');
                 }
@@ -47,7 +48,7 @@ angular.module('lumx.notification', [])
         function deleteNotification(notification)
         {
             var notifIndex = notificationList.indexOf(notification);
-            
+
             var dnOffset = 24 + notificationList[notifIndex].height;
 
             for (var idx = 0; idx < notifIndex; idx++)
@@ -168,7 +169,7 @@ angular.module('lumx.notification', [])
         }
 
         // private
-        function buildDialogActions(buttons, callback)
+        function buildDialogActions(buttons, callback, unbind)
         {
             var $compile = $injector.get('$compile');
 
@@ -220,10 +221,29 @@ angular.module('lumx.notification', [])
                 closeDialog();
             });
 
+            if (!unbind)
+            {
+                idEventScheduler = LxEventSchedulerService.register('keyup', function(event)
+                {
+                    if (event.keyCode == 13)
+                    {
+                        callback(true);
+                        closeDialog();
+                    }
+                    else if (event.keyCode == 27)
+                    {
+                        callback(false);
+                        closeDialog();
+                    }
+
+                    event.stopPropagation();
+                });
+            }
+
             return dialogActions;
         }
 
-        function confirm(title, text, buttons, callback)
+        function confirm(title, text, buttons, callback, unbind)
         {
             // DOM elements
             dialogFilter = angular.element('<div/>', {
@@ -246,7 +266,8 @@ angular.module('lumx.notification', [])
                 .append(dialogContent)
                 .append(dialogActions)
                 .appendTo('body')
-                .show();
+                .show()
+                .focus();
 
             // Starting animaton
             $timeout(function()
@@ -256,7 +277,7 @@ angular.module('lumx.notification', [])
             }, 100);
         }
 
-        function alert(title, text, button, callback)
+        function alert(title, text, button, callback, unbind)
         {
             // DOM elements
             dialogFilter = angular.element('<div/>', {
@@ -279,7 +300,8 @@ angular.module('lumx.notification', [])
                 .append(dialogContent)
                 .append(dialogActions)
                 .appendTo('body')
-                .show();
+                .show()
+                .focus();
 
             // Starting animaton
             $timeout(function()
@@ -292,6 +314,14 @@ angular.module('lumx.notification', [])
         // private
         function closeDialog()
         {
+            if (angular.isDefined(idEventScheduler))
+            {
+                $timeout(function() {
+                    LxEventSchedulerService.unregister(idEventScheduler);
+                    idEventScheduler = undefined;
+                }, 1);
+            }
+
             // Starting animaton
             dialogFilter.removeClass('dialog-filter--is-shown');
             dialog.removeClass('dialog--is-shown');

--- a/modules/notification/js/notification_service.js
+++ b/modules/notification/js/notification_service.js
@@ -256,7 +256,7 @@ angular.module('lumx.notification', ['lumx.utils.event-scheduler'])
 
             var dialogHeader = buildDialogHeader(title);
             var dialogContent = buildDialogContent(text);
-            var dialogActions = buildDialogActions(buttons, callback);
+            var dialogActions = buildDialogActions(buttons, callback, unbind);
 
             // DOM link
             dialogFilter.appendTo('body');
@@ -290,7 +290,7 @@ angular.module('lumx.notification', ['lumx.utils.event-scheduler'])
 
             var dialogHeader = buildDialogHeader(title);
             var dialogContent = buildDialogContent(text);
-            var dialogActions = buildDialogActions({ ok: button }, callback);
+            var dialogActions = buildDialogActions({ ok: button }, callback, unbind);
 
             // DOM link
             dialogFilter.appendTo('body');


### PR DESCRIPTION
This new feature will add the ability to close a dialog, dropdown or
confirm/alert with the escape key.
Moreover, for the confirm, the enter key will allow to validate the
confirm

Added with this feature is an event scheduler which allow to execute
events in the reverse order of events registration. This way, when
a dropdown opens in a dialog, the first escape key hit will close the
dropdown, the next one, the dialog.