### PR TITLE
feat tooltip: allow to update the tooltip content

### DIFF
--- a/modules/tooltip/js/tooltip_directive.js
+++ b/modules/tooltip/js/tooltip_directive.js
@@ -99,14 +99,28 @@ angular.module('lumx.tooltip', [])
             tooltip.addClass('tooltip--is-active');
         };
 
+        this.update = function(content)
+        {
+            tooltipContent = content;
+            tooltipLabel.text(tooltipContent);
+        };
+
         this.hideTooltip = function()
         {
-            tooltip.removeClass('tooltip--is-active');
-
-            $timeout(function()
+            if (angular.isDefined(tooltip))
             {
-                tooltip.remove();
-            }, 200);
+                tooltip.removeClass('tooltip--is-active');
+
+                $timeout(function()
+                {
+                    tooltip.remove();
+                }, 200);
+            }
+        };
+
+        this.isDisplayed = function()
+        {
+            return angular.isDefined(tooltip) && tooltip.hasClass('tooltip--is-active');
         };
 
         $scope.$on('$destroy', function(scope)
@@ -125,7 +139,18 @@ angular.module('lumx.tooltip', [])
                 {
                     if (attrs.lxTooltip)
                     {
-                        ctrl.init(element, attrs);
+                        if (ctrl.isDisplayed())
+                        {
+                            ctrl.update(attrs.lxTooltip);
+                        }
+                        else
+                        {
+                            ctrl.init(element, attrs);
+                        }
+                    }
+                    else
+                    {
+                        ctrl.hideTooltip();
                     }
                 });
             }


### PR DESCRIPTION
Without this fix, when two-way binding "lx-tooltip", the remains
displayed when changing the value of the tooltip.