### PR TITLE
fix tooltip: don't destroy tooltip if undefined

### DIFF
--- a/modules/tooltip/js/tooltip_directive.js
+++ b/modules/tooltip/js/tooltip_directive.js
@@ -125,7 +125,10 @@ angular.module('lumx.tooltip', [])
 
         $scope.$on('$destroy', function(scope)
         {
-            tooltip.remove();
+            if (angular.isDefined(tooltip))
+            {
+                tooltip.remove();
+            }
         });
     }])
     .directive('lxTooltip', function()


### PR DESCRIPTION
This will fix any problems in ng-repeats

Fix #291