### PR TITLE
fix gulpfile: use cross-platform manipulations with file paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 var gulp = require('gulp'),
+    path = require('path'),
     minimist = require('minimist'),
     summary = require('jshint-summary'),
     del = require('del'),
@@ -85,9 +86,9 @@ gulp.task('lint', function()
         .pipe(plugins.jshint.reporter('jshint-summary'))
         .pipe(plugins.jshint.reporter('fail'))
         .pipe(plugins.remember('lint'))
-        .pipe(plugins.rename(function(path)
+        .pipe(plugins.rename(function(p)
         {
-            path.dirname = path.dirname.replace('/js', '');
+            p.dirname = p.dirname.replace(path.normalize('/js'), '');
         }))
         .pipe(gulp.dest('build/js'));
 });
@@ -119,9 +120,9 @@ gulp.task('examples', function()
 {
     return gulp.src(paths.examples)
         .pipe(plugins.plumber())
-        .pipe(plugins.rename(function(path)
+        .pipe(plugins.rename(function(p)
         {
-            path.dirname = path.dirname.replace('/demo', '');
+            p.dirname = p.dirname.replace(path.normalize('/demo'), '');
         }))
         .pipe(gulp.dest('build/includes/modules'));
 });
@@ -186,7 +187,7 @@ gulp.task('tpl:dropdown', function()
         .pipe(plugins.templatecache({
             output: 'dropdown_template.js',
             moduleName: 'lumx.dropdown',
-            strip: 'views/'
+            strip: path.normalize('views/')
         }))
         .pipe(gulp.dest('build/js/templates'));
 });
@@ -198,7 +199,7 @@ gulp.task('tpl:file-input', function()
         .pipe(plugins.templatecache({
             output: 'file-input_template.js',
             moduleName: 'lumx.file-input',
-            strip: 'views/'
+            strip: path.normalize('views/')
         }))
         .pipe(gulp.dest('build/js/templates'));
 });
@@ -210,7 +211,7 @@ gulp.task('tpl:text-field', function()
         .pipe(plugins.templatecache({
             output: 'text-field_template.js',
             moduleName: 'lumx.text-field',
-            strip: 'views/'
+            strip: path.normalize('views/')
         }))
         .pipe(gulp.dest('build/js/templates'));
 });
@@ -222,7 +223,7 @@ gulp.task('tpl:search-filter', function()
         .pipe(plugins.templatecache({
             output: 'search-filter_template.js',
             moduleName: 'lumx.search-filter',
-            strip: 'views/'
+            strip: path.normalize('views/')
         }))
         .pipe(gulp.dest('build/js/templates'));
 });
@@ -234,7 +235,7 @@ gulp.task('tpl:select', function()
         .pipe(plugins.templatecache({
             output: 'select_template.js',
             moduleName: 'lumx.select',
-            strip: 'views/'
+            strip: path.normalize('views/')
         }))
         .pipe(gulp.dest('build/js/templates'));
 });
@@ -246,7 +247,7 @@ gulp.task('tpl:tabs', function()
         .pipe(plugins.templatecache({
             output: 'tabs_template.js',
             moduleName: 'lumx.tabs',
-            strip: 'views/'
+            strip: path.normalize('views/')
         }))
         .pipe(gulp.dest('build/js/templates'));
 });
@@ -258,7 +259,7 @@ gulp.task('tpl:date-picker', function()
         .pipe(plugins.templatecache({
             output: 'date-picker_template.js',
             moduleName: 'lumx.date-picker',
-            strip: 'views/'
+            strip: path.normalize('views/')
         }))
         .pipe(gulp.dest('build/js/templates'));
 });
@@ -270,7 +271,7 @@ gulp.task('tpl:progress', function()
         .pipe(plugins.templatecache({
             output: 'progress_template.js',
             moduleName: 'lumx.progress',
-            strip: 'views/'
+            strip: path.normalize('views/')
         }))
         .pipe(gulp.dest('build/js/templates'));
 });


### PR DESCRIPTION
Build output was incorrect on Windows. The problem is that Windows uses backslashes in file paths. Now the project is built on Windows too.

Fix #382