### PR TITLE
fix scrollbar: firefox support

### DIFF
--- a/core/js/utils/utils_service.js
+++ b/core/js/utils/utils_service.js
@@ -3,7 +3,7 @@
 
 
 angular.module('lumx.utils.utils', [])
-    .service('LxUtils', function()
+    .service('LxUtils', ['$window', function($window)
     {
         function generateUUID()
         {
@@ -20,7 +20,13 @@ angular.module('lumx.utils.utils', [])
             return uuid.toUpperCase();
         }
 
+        function getEmSize(el)
+        {
+            return Number($window.getComputedStyle(el, "").fontSize.match(/(\d+)px/)[1]);
+        }
+
         return {
-            generateUUID: generateUUID
+            generateUUID: generateUUID,
+            getEmSize: getEmSize
         };
-    });
+    }]);

--- a/modules/scrollbar/js/scrollbar_directive.js
+++ b/modules/scrollbar/js/scrollbar_directive.js
@@ -34,8 +34,8 @@ angular.module('lumx.scrollbar', [])
         };
 
     }])
-    .controller('LxScrollbarController', ['$scope', '$window', 'LxScrollbarService',
-        function($scope, $window, LxScrollbarService)
+    .controller('LxScrollbarController', ['$scope', '$window', 'LxScrollbarService', 'LxUtils',
+        function($scope, $window, LxScrollbarService, LxUtils)
     {
         var mousePosition,
             scrollbarId,
@@ -121,16 +121,27 @@ angular.module('lumx.scrollbar', [])
                 }
             });
 
-            scrollbarContainer.bind('mousewheel', function(event)
+            scrollbarContainer.bind('wheel', function(event)
             {
                 if ($window.innerWidth >= 1024)
                 {
                     event.preventDefault();
 
                     var scrollPercent = scrollbarContainer.scrollTop() / scrollBottom,
-                        scrollPosition = (scrollbarContainerHeight - scrollbarYAxisHandle.outerHeight()) * scrollPercent;
+                        scrollPosition = (scrollbarContainerHeight - scrollbarYAxisHandle.outerHeight()) * scrollPercent,
+                        deltaY = 0;
 
-                    updateScroll(scrollPosition, scrollbarContainer.scrollTop() + event.originalEvent.wheelDelta * -1);
+                    switch(event.originalEvent.deltaMode)
+                    {
+                    case $window.WheelEvent.DOM_DELTA_PIXEL :
+                        deltaY = event.originalEvent.deltaY;
+                        break;
+                    case $window.WheelEvent.DOM_DELTA_LINE :
+                        deltaY = LxUtils.getEmSize(event.originalEvent.target)*event.originalEvent.deltaY;
+                        break;
+                    }
+
+                    updateScroll(scrollPosition, scrollbarContainer.scrollTop() + deltaY*0.5);
                 }
             });
 


### PR DESCRIPTION
The mousewheel event is no longer supported in firefox.
I replaced the deprecated mousewheel event with the new wheel event and added support for multiple delta modes to make the experience uniform across different browsers.
Now the scrollbar works almost the same on both chrome and firefox.