### PR TITLE
fix datepicker: issue 332, onclick does not work in FireFox

### DIFF
--- a/modules/date-picker/views/date-picker.html
+++ b/modules/date-picker/views/date-picker.html
@@ -9,6 +9,7 @@
     <div class="lx-date__input-wrapper">
         <lx-text-field class="lx-date-input" label="{{ label }}" ng-click="openPicker()">
             <input type="text" ng-model="selected.model" ng-disabled="true">
+            <div style="position:absolute; left:0; right:0; top:0; bottom:0;"></div>
         </lx-text-field>
 
         <a class="lx-date__clear" ng-click="clearDate()" ng-if="allowClear">


### PR DESCRIPTION
Fix for #332 
Disabled elements don't fire mouse events. Most browsers will propagate an event originating from the disabled element up the DOM tree, so event handlers could be placed on container elements. However, Firefox doesn't exhibit this behaviour, it just does nothing at all when you click on a disabled element.
Found and copied from: http://stackoverflow.com/questions/3100319/event-on-a-disabled-input