### PR TITLE
Fix typo in doc

### DIFF
--- a/modules/dialog/demo/includes/basic.html
+++ b/modules/dialog/demo/includes/basic.html
@@ -47,7 +47,7 @@
             <lx-tab-pane>
                 <p class="p++">Lorem Ipsum Content 3</p>
             </lx-tab-pane>
-        </lx-panes>
+        </lx-tab-panes>
     </lx-dialog-content>
  
     <lx-dialog-footer>


### PR DESCRIPTION
I believe the doc should read `</lx-tab-panes>` rather than `</lx-panes>`