### PR TITLE
Using unquote to escape deprecation warning...

### DIFF
--- a/core/scss/base/_flexbox.scss
+++ b/core/scss/base/_flexbox.scss
@@ -200,7 +200,7 @@
     [flex-container="row"] > [flex-item="#{$i}"],
     [flex-container="row"][flex-column="12"] > [flex-item="#{$i}"] {
         @include media-query(desk) {
-            @include flex(0 0 #{(100 / 12) * $i + '%'});
+            @include flex(unquote('0 0 #{(100 / 12) * $i + '%'}'));
             max-width: #{(100 / 12) * $i + '%'};
         }
     }
@@ -208,7 +208,7 @@
     [flex-container="column"] > [flex-item="#{$i}"],
     [flex-container="column"][flex-column="12"] > [flex-item="#{$i}"] {
         @include media-query(desk) {
-            @include flex(0 0 #{(100 / 12) * $i + '%'});
+            @include flex(unquote('0 0 #{(100 / 12) * $i + '%'}'));
             max-height: #{(100 / 12) * $i + '%'};
         }
     }
@@ -217,14 +217,14 @@
 @for $i from 1 through 16 {
     [flex-container="row"][flex-column="16"] > [flex-item="#{$i}"] {
         @include media-query(desk) {
-            @include flex(0 0 #{(100 / 16) * $i + '%'});
+            @include flex(unquote('0 0 #{(100 / 16) * $i + '%'}'));
             max-width: #{(100 / 16) * $i + '%'};
         }
     }
 
     [flex-container="column"][flex-column="16"] > [flex-item="#{$i}"] {
         @include media-query(desk) {
-            @include flex(0 0 #{(100 / 16) * $i + '%'});
+            @include flex(unquote('0 0 #{(100 / 16) * $i + '%'}'));
             max-height: #{(100 / 16) * $i + '%'};
         }
     }

--- a/modules/date-picker/scss/_date-picker.scss
+++ b/modules/date-picker/scss/_date-picker.scss
@@ -175,7 +175,7 @@
 
     // Date picker: day
     .lx-date-picker__day {
-        @include flex(0 0 #{(100 / 7) + '%'});
+        @include flex(unquote('0 0 #{(100 / 7) + '%'}'));
         max-width: #{(100 / 7) + '%'};
         padding: 1px 0;
 


### PR DESCRIPTION
When compile SASS is showing warning message like this:

`DEPRECATION WARNING on line 178 of node_modules/lumx/modules/date-picker/scss/_date-picker.scss: #{} interpolation near operators will be simplified in a future version of Sass. To preserve the current behavior, use quotes`

To preserve the current behavior, this pull request used unquote method and everything OK with no messages. :+1: 