### PR TITLE
Update select_directive.js

### DIFF
--- a/modules/select/js/select_directive.js
+++ b/modules/select/js/select_directive.js
@@ -340,7 +340,11 @@
 
                 for (var i = 0; i < clone.length; i++)
                 {
-                    template += clone[i].outerHTML || '';
+                    if(clone[i].outerHTML !== undefined)
+                        template += clone[i].outerHTML || '';
+                    else
+                        template += clone[i].nodeValue || '';
+                    
                 }
 
                 ctrls[1].registerSelectedTemplate(template);
@@ -402,7 +406,10 @@
 
                 for (var i = 0; i < clone.length; i++)
                 {
-                    template += clone[i].outerHTML || '';
+                    if(clone[i].outerHTML !== undefined)
+                        template += clone[i].outerHTML || '';
+                    else
+                        template += clone[i].nodeValue || '';
                 }
 
                 ctrls[1].registerChoiceTemplate(template);


### PR DESCRIPTION
Avaliable selections were not visible due to outerHTML not avaliable in object that resulted in lost template. Don't know the exact reason maybe deprecation in angular? This patch uses nodeValue if outerHTML not present witch seems to work properly.