### PR TITLE
firstDayOfMonth issue.

### DIFF
--- a/modules/date-picker/js/date-picker_directive.js
+++ b/modules/date-picker/js/date-picker_directive.js
@@ -132,7 +132,7 @@
 
             var previousDay = angular.copy(lxDatePicker.ngModelMoment).date(0);
             var firstDayOfMonth = angular.copy(lxDatePicker.ngModelMoment).date(1);
-            var lastDayOfMonth = firstDayOfMonth.endOf('month');
+            var lastDayOfMonth = firstDayOfMonth.clone().endOf('month');
             var maxDays = lastDayOfMonth.date();
 
             lxDatePicker.emptyFirstDays = [];


### PR DESCRIPTION
Add the clone() for the lastDayOfMonth in date-picker_directive.js LINE 135.

Cause the `var lastDayOfMonth = firstDayOfMonth.endOf('month');` will overwrite the `firstDayOfMonth` so the calendar will show the wrong day of week.