### PR TITLE
Replace invisible 'Â' character with a space

### DIFF
--- a/modules/text-field/views/text-field.html
+++ b/modules/text-field/views/text-field.html
@@ -8,7 +8,7 @@
                  'text-field--is-focus': lxTextField.isFocus,
                  'text-field--theme-light': !lxTextField.theme || lxTextField.theme === 'light',
                  'text-field--theme-dark': lxTextField.theme === 'dark',
-                 'text-field--valid': lxTextField.valid }">
+                 'text-field--valid': lxTextField.valid }">
     <div class="text-field__icon" ng-if="lxTextField.icon">
         <i class="mdi mdi-{{ lxTextField.icon }}"></i>
     </div>


### PR DESCRIPTION
Prevents a lexerr in Angular to fix #444 