### PR TITLE
fix dialog: only process closing if dialog is really opened

### DIFF
--- a/modules/dialog/js/dialog_directive.js
+++ b/modules/dialog/js/dialog_directive.js
@@ -173,6 +173,11 @@
 
         function open()
         {
+            if (lxDialog.isOpen)
+            {
+                return;
+            }
+            
             LxDepthService.register();
 
             angular.element('body').addClass('no-scroll-dialog-' + lxDialog.uuid);
@@ -237,6 +242,11 @@
 
         function close()
         {
+            if (!lxDialog.isOpen)
+            {
+                return;
+            }
+            
             if (angular.isDefined(idEventScheduler))
             {
                 LxEventSchedulerService.unregister(idEventScheduler);


### PR DESCRIPTION
`close` can be called by various event, particularly when the dialog is
destroyed. Thus, making the `lx-dialog__close-start` and `lx-dialog__
close-end` events beeing sent, even if the dialog wasn't really opened
The same case can occurs at opening.