### PR TITLE
fix(tabs): update the viewMode when links changes

### DIFF
--- a/modules/tabs/js/tabs_directive.js
+++ b/modules/tabs/js/tabs_directive.js
@@ -79,6 +79,8 @@
             return lxTabs.links;
         }, function(_newLinks)
         {
+            lxTabs.viewMode = angular.isDefined(_newLinks) ? 'separate' : 'gather';
+            
             angular.forEach(_newLinks, function(link, index)
             {
                 var tab = {


### PR DESCRIPTION
If links is not set at init, then the view mode is not set at 'separate'