### PR TITLE
Fix/angular 1.6.0 upgrade fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -51,7 +51,7 @@
     },
     "devDependencies":
     {
-        "angular-ui-router": "~0.2.15",
-        "angular-highlightjs": "~0.5.1"
+        "angular-ui-router": "latest",
+        "angular-highlightjs": "latest"
     }
 }

--- a/modules/select/demo/js/demo-select_controller.js
+++ b/modules/select/demo/js/demo-select_controller.js
@@ -24,14 +24,14 @@
                     vm.selectAjax.loading = true;
 
                     $http.get('http://www.omdbapi.com/?s=' + escape(newFilter))
-                        .success(function(data)
+                        .then(function updateSuccess(data)
                         {
                             vm.selectAjax.list = data.Search;
                             vm.selectAjax.loading = false;
-                        })
-                        .error(function()
+                        },
+                        function updateError()
                         {
-                            vm.selectAjax.loading = false;
+                                vm.selectAjax.loading = false;
                         });
                 }
                 else
@@ -55,11 +55,10 @@
                 if (data)
                 {
                     $http.get('http://www.omdbapi.com/?s=' + escape(data))
-                        .success(function(response)
+                        .then(function toSelectionSuccess(response)
                         {
                             callback(response.Search[0]);
-                        })
-                        .error(function()
+                        }, function toSelectionError()
                         {
                             callback();
                         });

--- a/modules/select/demo/js/demo-select_controller.js
+++ b/modules/select/demo/js/demo-select_controller.js
@@ -24,14 +24,17 @@
                     vm.selectAjax.loading = true;
 
                     $http.get('http://www.omdbapi.com/?s=' + escape(newFilter))
-                        .then(function updateSuccess(data)
+                        .then(function updateSuccess(response)
                         {
-                            vm.selectAjax.list = data.Search;
+                            if (response.data)
+                            {
+                                vm.selectAjax.list = response.data.Search;
+                            }
                             vm.selectAjax.loading = false;
-                        },
-                        function updateError()
+                        })
+                        .catch(function updateError()
                         {
-                                vm.selectAjax.loading = false;
+                            vm.selectAjax.loading = false;
                         });
                 }
                 else
@@ -57,8 +60,12 @@
                     $http.get('http://www.omdbapi.com/?s=' + escape(data))
                         .then(function toSelectionSuccess(response)
                         {
-                            callback(response.Search[0]);
-                        }, function toSelectionError()
+                            if (response.data)
+                            {
+                                callback(response.data.Search[0]);
+                            }
+                        })
+                        .catch(function toSelectionError()
                         {
                             callback();
                         });

--- a/modules/select/js/select_directive.js
+++ b/modules/select/js/select_directive.js
@@ -342,7 +342,7 @@
 
                 for (var i = 0; i < clone.length; i++)
                 {
-                    template += clone[i].outerHTML || '';
+                    template += clone[i].data || '';
                 }
 
                 ctrls[1].registerSelectedTemplate(template);
@@ -404,7 +404,7 @@
 
                 for (var i = 0; i < clone.length; i++)
                 {
-                    template += clone[i].outerHTML || '';
+                    template += clone[i].data || '';
                 }
 
                 ctrls[1].registerChoiceTemplate(template);


### PR DESCRIPTION
Not 100% sure what is going on with the transclude function... The clone element is different between 1.5.9 and latest angularjs (one is a text node, the other is a span element, which is why on the text node we don't have the outerHTML attr).

Maybe related to the jQuery update as well (jqLite / jQuery 3 ships in Angular 1.6.0)... @clementprevot may know?

Needs a bit of testing I reckon.