### PR TITLE
chore: freeze bourbon version until we sort out the warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,7 @@
         "jquery": "latest",
         "velocity": "latest",
         "moment": "latest",
-        "bourbon": "latest",
+        "bourbon": "~4.2.7",
         "mdi": "latest"
     },
     "devDependencies":


### PR DESCRIPTION
Freezing the bourbon version to the one just before they added all the deprecated warnings. This is temporary until we sort out those warnings to avoid messy console logs.