### PR TITLE
fix(date-picker): keep today color white on hover

### DIFF
--- a/modules/date-picker/scss/_date-picker.scss
+++ b/modules/date-picker/scss/_date-picker.scss
@@ -56,7 +56,7 @@
             background-color: $color;
         }
 
-        .lx-date-picker__day--is-today a {
+        .lx-date-picker__day--is-today a:not(:hover) {
             color: $color;
         }
 


### PR DESCRIPTION
When you focus today, you can have same color for background and font.
This PR doesn't apply color if today is hover.

<img width="344" alt="screen_shot_2017-03-17_at_15 06 35" src="https://cloud.githubusercontent.com/assets/6814372/24050130/354d06d2-0b2e-11e7-997f-ee22cc20474c.png">
