### PR TITLE
fix: upgrade mdi to 1.9.33

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
         "velocity": "latest",
         "moment": "latest",
         "bourbon": "~4.2.7",
-        "mdi": "1.8.36"
+        "mdi": "1.9.33"
     },
     "devDependencies":
     {


### PR DESCRIPTION
Some icons like `format-align-justify` are missing with 1.8.36