### PR TITLE
fix(sass): update mdi-icon mixin

### DIFF
--- a/core/scss/tools/_mixins.scss
+++ b/core/scss/tools/_mixins.scss
@@ -48,7 +48,7 @@
 }
 
 @mixin mdi-icon($icon) {
-    content: char(map-get($mdi-icons, $icon));
+    content: mdi($icon);
 }
 
 


### PR DESCRIPTION
Use new mdi function to avoid css error with bad name.

Before : If icon name doesn't existe, we have `content: "\";` 
The `/` escapes the `"` and next lines are commented.

Now :  If icon name doesn't existe, we have `content: ""` and a warning in Gulp .
Sample : 
`WARNING: Icon quote not found.
Backtrace: libs/mdi/scss/_functions.scss:16, in function 'mdi'
	core/scss/tools/_mixins.scss:51, in mixin 'mdi-icon'
	modules/radio-button/scss/_radio-button.scss:102`