### PR TITLE
fix search-filter: clearing input should not trigger a search again

### DIFF
--- a/modules/search-filter/js/search-filter_directive.js
+++ b/modules/search-filter/js/search-filter_directive.js
@@ -138,7 +138,13 @@
             lxSearchFilter.modelController.$setViewValue(undefined);
             lxSearchFilter.modelController.$render();
 
+            // Temporarily disabling search on focus since we never want to trigger it when clearing the input.
+            var searchOnFocus = lxSearchFilter.searchOnFocus;
+            lxSearchFilter.searchOnFocus = false;
+
             input.focus();
+
+            lxSearchFilter.searchOnFocus = searchOnFocus;
         }
 
         function focusInput()


### PR DESCRIPTION
it was still triggering a search (even though it wasn't displaying anything) because we focus the input right away after clearing it