### PR TITLE
feat(notification): always call the callback when the notif closes

### DIFF
--- a/modules/notification/js/notification_service.js
+++ b/modules/notification/js/notification_service.js
@@ -15,6 +15,7 @@
         var dialog;
         var idEventScheduler;
         var notificationList = [];
+        var actionClicked = false;
 
         service.alert = showAlertDialog;
         service.confirm = showConfirmDialog;
@@ -61,7 +62,7 @@
                     notificationList.splice(notifIndex, 1);
                 }
 
-                _callback();
+                _callback(actionClicked);
             }, 400);
         }
 
@@ -145,6 +146,11 @@
 
                 notificationAction.attr('lx-ripple', '');
                 $compile(notificationAction)($rootScope);
+
+                notificationAction.bind('click', function()
+                {
+                    actionClicked = true;
+                });
 
                 notification
                     .addClass('notification--has-action')

--- a/modules/notification/js/notification_service.js
+++ b/modules/notification/js/notification_service.js
@@ -30,8 +30,10 @@
         // NOTIFICATION
         //
 
-        function deleteNotification(_notification)
+        function deleteNotification(_notification, _callback)
         {
+            _callback = (!angular.isFunction(_callback)) ? angular.noop : _callback;
+
             var notifIndex = notificationList.indexOf(_notification);
 
             var dnOffset = angular.isDefined(notificationList[notifIndex]) ? 24 + notificationList[notifIndex].height : 24;
@@ -58,6 +60,8 @@
                 {
                     notificationList.splice(notifIndex, 1);
                 }
+
+                _callback();
             }, 400);
         }
 
@@ -145,11 +149,6 @@
                 notification
                     .addClass('notification--has-action')
                     .append(notificationAction);
-
-                notificationAction.bind('click', function()
-                {
-                    _callback();
-                });
             }
 
             notification
@@ -170,7 +169,7 @@
 
             notification.bind('click', function()
             {
-                deleteNotification(data);
+                deleteNotification(data, _callback);
 
                 if (angular.isDefined(notificationTimeout))
                 {
@@ -182,7 +181,7 @@
             {
                 notificationTimeout = $timeout(function()
                 {
-                    deleteNotification(data);
+                    deleteNotification(data, _callback);
                 }, notificationDelay);
             }
         }

--- a/modules/notification/js/notification_service.js
+++ b/modules/notification/js/notification_service.js
@@ -63,6 +63,7 @@
                 }
 
                 _callback(actionClicked);
+                actionClicked = false
             }, 400);
         }
 


### PR DESCRIPTION
Not only when there is an action.
This way, it allow to have an action when a notification closes, either
by clicking on it or when the delay is expired