### PR TITLE
feat dialog service extra parameters

### DIFF
--- a/modules/dialog/demo/dialog.html
+++ b/modules/dialog/demo/dialog.html
@@ -45,7 +45,7 @@
     </lx-component-attributes>
 
     <lx-component-methods lx-title="Service api">
-        <lx-component-method lx-name="LxDialogService.open(dialogId)" lx-description="Show a dialog according to its id.">
+        <lx-component-method lx-name="LxDialogService.open(dialogId, params)" lx-description="Show a dialog according to its id.">
             <table>
                 <thead>
                     <tr>
@@ -60,12 +60,17 @@
                         <td>dialogId*</td>
                         <td><code>string</code></td>
                         <td>The dialog id specified in the directive id attribute.</td>
+                    </tr>
+                    <tr>
+                        <td>params</td>
+                        <td><code>object</code></td>
+                        <td>An optional object that holds extra parameters that will be forwarded to the <code>lx-dialog__open-start</code> and <code>lx-dialog__open-end</code> events.</td>
                     </tr>
                 </tbody>
             </table>
         </lx-component-method>
 
-        <lx-component-method lx-name="LxDialogService.close(dialogId)" lx-description="Close a dialog according to its id.">
+        <lx-component-method lx-name="LxDialogService.close(dialogId, canceled, params)" lx-description="Close a dialog according to its id.">
             <table>
                 <thead>
                     <tr>
@@ -80,6 +85,16 @@
                         <td>dialogId*</td>
                         <td><code>string</code></td>
                         <td>The dialog id specified in the directive id attribute.</td>
+                    </tr>
+                    <tr>
+                        <td>canceled</td>
+                        <td><code>boolean</code></td>
+                        <td>Indicates if the dialog was closed via a cancel or not.</td>
+                    </tr>
+                    <tr>
+                        <td>params</td>
+                        <td><code>object</code></td>
+                        <td>An optional object that holds extra parameters that will be forwarded to the <code>lx-dialog__close-start</code> and <code>lx-dialog__close-end</code> events.</td>
                     </tr>
                 </tbody>
             </table>
@@ -108,6 +123,11 @@
                         <td><code>string</code></td>
                         <td>The dialog id specified in the directive id attribute.</td>
                     </tr>
+                    <tr>
+                        <td>params</td>
+                        <td><code>object</code></td>
+                        <td>An optional object that holds extra parameters originally passed to the <code>open</code> method.</td>
+                    </tr>
                 </tbody>
             </table>
         </lx-component-method>
@@ -132,6 +152,11 @@
                         <td>dialogId</td>
                         <td><code>string</code></td>
                         <td>The dialog id specified in the directive id attribute.</td>
+                    </tr>
+                    <tr>
+                        <td>params</td>
+                        <td><code>object</code></td>
+                        <td>An optional object that holds extra parameters originally passed to the <code>open</code> method.</td>
                     </tr>
                 </tbody>
             </table>
@@ -158,6 +183,16 @@
                         <td><code>string</code></td>
                         <td>The dialog id specified in the directive id attribute.</td>
                     </tr>
+                    <tr>
+                        <td>canceled</td>
+                        <td><code>boolean</code></td>
+                        <td>Indicates if the dialog was closed via a cancel or not.</td>
+                    </tr>
+                    <tr>
+                        <td>params</td>
+                        <td><code>object</code></td>
+                        <td>An optional object that holds extra parameters originally passed to the <code>close</code> method.</td>
+                    </tr>
                 </tbody>
             </table>
         </lx-component-method>
@@ -182,6 +217,16 @@
                         <td>dialogId</td>
                         <td><code>string</code></td>
                         <td>The dialog id specified in the directive id attribute.</td>
+                    </tr>
+                    <tr>
+                        <td>canceled</td>
+                        <td><code>boolean</code></td>
+                        <td>Indicates if the dialog was closed via a cancel or not.</td>
+                    </tr>
+                    <tr>
+                        <td>params</td>
+                        <td><code>object</code></td>
+                        <td>An optional object that holds extra parameters originally passed to the <code>close</code> method.</td>
                     </tr>
                 </tbody>
             </table>

--- a/modules/dialog/demo/js/demo-dialog_controller.js
+++ b/modules/dialog/demo/js/demo-dialog_controller.js
@@ -58,15 +58,15 @@
             age: 21
         }];
 
-        $scope.$on('lx-dialog__open-start', function(_event, _dialogId)
+        $scope.$on('lx-dialog__open-start', function(_event, _dialogId, _params)
         {
             if (vm.dialogId === _dialogId)
             {
-                LxNotificationService.notify('Open start');
+                LxNotificationService.notify('Open start ' + _params.customMessage);
             }
         });
 
-        $scope.$on('lx-dialog__open-end', function(_event, _dialogId)
+        $scope.$on('lx-dialog__open-end', function(_event, _dialogId, _params)
         {
             if (vm.dialogId === _dialogId)
             {
@@ -74,7 +74,7 @@
             }
         });
 
-        $scope.$on('lx-dialog__close-start', function(_event, _dialogId)
+        $scope.$on('lx-dialog__close-start', function(_event, _dialogId, _params)
         {
             if (vm.dialogId === _dialogId)
             {
@@ -82,7 +82,7 @@
             }
         });
 
-        $scope.$on('lx-dialog__close-end', function(_event, _dialogId)
+        $scope.$on('lx-dialog__close-end', function(_event, _dialogId, _params)
         {
             if (vm.dialogId === _dialogId)
             {
@@ -112,7 +112,9 @@
 
         function openDialog()
         {
-            LxDialogService.open(vm.dialogId);
+            LxDialogService.open(vm.dialogId, {
+                customMessage: 'Hello World!',
+            });
         }
     }
 })();

--- a/modules/dialog/js/dialog_directive.js
+++ b/modules/dialog/js/dialog_directive.js
@@ -60,19 +60,19 @@
         lxDialog.isOpen = false;
         lxDialog.uuid = LxUtils.generateUUID();
 
-        $scope.$on('lx-dialog__open', function(event, id)
+        $scope.$on('lx-dialog__open', function(event, id, params)
         {
             if (id === lxDialog.id)
             {
-                open();
+                open(params);
             }
         });
 
-        $scope.$on('lx-dialog__close', function(event, id, canceled)
+        $scope.$on('lx-dialog__close', function(event, id, canceled, params)
         {
             if (id === lxDialog.id)
             {
-                close(canceled);
+                close(canceled, params);
             }
         });
 
@@ -171,7 +171,7 @@
             _event.stopPropagation();
         }
 
-        function open()
+        function open(_params)
         {
             if (lxDialog.isOpen)
             {
@@ -206,7 +206,7 @@
 
             $timeout(function()
             {
-                $rootScope.$broadcast('lx-dialog__open-start', lxDialog.id);
+                $rootScope.$broadcast('lx-dialog__open-start', lxDialog.id, _params);
 
                 lxDialog.isOpen = true;
 
@@ -229,7 +229,7 @@
 
             $timeout(function()
             {
-                $rootScope.$broadcast('lx-dialog__open-end', lxDialog.id);
+                $rootScope.$broadcast('lx-dialog__open-end', lxDialog.id, _params);
             }, 700);
 
             dialogInterval = $interval(function()
@@ -240,12 +240,14 @@
             angular.element($window).on('resize', checkDialogHeightOnResize);
         }
 
-        function close(canceled)
+        function close(_canceled, _params)
         {
             if (!lxDialog.isOpen)
             {
                 return;
             }
+
+            _params = _params || {};
 
             if (angular.isDefined(idEventScheduler))
             {
@@ -256,7 +258,7 @@
             angular.element($window).off('resize', checkDialogHeightOnResize);
             $element.find('.dialog__scrollable').off('scroll', checkScrollEnd);
 
-            $rootScope.$broadcast('lx-dialog__close-start', lxDialog.id, canceled);
+            $rootScope.$broadcast('lx-dialog__close-start', lxDialog.id, _canceled, _params);
 
             if (resizeDebounce)
             {
@@ -281,7 +283,7 @@
 
                 lxDialog.isOpen = false;
                 dialogHeight = undefined;
-                $rootScope.$broadcast('lx-dialog__close-end', lxDialog.id, canceled);
+                $rootScope.$broadcast('lx-dialog__close-end', lxDialog.id, _canceled, _params);
             }, 600);
         }
     }

--- a/modules/dialog/js/dialog_service.js
+++ b/modules/dialog/js/dialog_service.js
@@ -17,14 +17,14 @@
 
         ////////////
 
-        function open(_dialogId)
+        function open(_dialogId, _params)
         {
-            $rootScope.$broadcast('lx-dialog__open', _dialogId);
+            $rootScope.$broadcast('lx-dialog__open', _dialogId, _params);
         }
 
-        function close(_dialogId, canceled)
+        function close(_dialogId, _canceled, _params)
         {
-            $rootScope.$broadcast('lx-dialog__close', _dialogId, canceled);
+            $rootScope.$broadcast('lx-dialog__close', _dialogId, _canceled, _params);
         }
     }
 })();


### PR DESCRIPTION
Allow to pass in extra parameters to the open and close method of a dialog so we can have extra logic when listening to the related events (open-start / open-end and close-start / close-end).

@clementprevot I have refactored your recent change with canceled so it's now an object rather than a boolean (so we can have multiple params and keep things clean).