### PR TITLE
feat(dialog-service-close): changing close trigger behavior

### DIFF
--- a/modules/dialog/js/dialog_directive.js
+++ b/modules/dialog/js/dialog_directive.js
@@ -70,7 +70,7 @@
 
         $scope.$on('lx-dialog__close', function(event, id, canceled, params)
         {
-            if (id === lxDialog.id)
+            if (id === lxDialog.id || id === undefined)
             {
                 close(canceled, params);
             }


### PR DESCRIPTION
Allowing user to close currently displayed dialog when no id is provided