### PR TITLE
fix(progress): add size to container

### DIFF
--- a/modules/progress/js/progress_directive.js
+++ b/modules/progress/js/progress_directive.js
@@ -29,6 +29,7 @@
     {
         var lxProgress = this;
 
+        lxProgress.getContainerProgressDimension = getContainerProgressDimension;
         lxProgress.getCircularProgressValue = getCircularProgressValue;
         lxProgress.getLinearProgressValue = getLinearProgressValue;
         lxProgress.getProgressDiameter = getProgressDiameter;
@@ -45,6 +46,19 @@
                     'stroke-dasharray': lxProgress.lxValue * 1.26 + ',200'
                 };
             }
+        }
+
+        function getContainerProgressDimension()
+        {
+            if (lxProgress.lxType === 'circular')
+            {
+                return {
+                    'height': lxProgress.lxDiameter + 'px',
+                    'width': lxProgress.lxDiameter + 'px',
+                };
+            }
+
+            return;
         }
 
         function getLinearProgressValue()

--- a/modules/progress/views/progress.html
+++ b/modules/progress/views/progress.html
@@ -1,6 +1,7 @@
 <div class="progress-container progress-container--{{ lxProgress.lxType }} progress-container--{{ lxProgress.lxColor }}"
      ng-class="{ 'progress-container--determinate': lxProgress.lxValue,
-                 'progress-container--indeterminate': !lxProgress.lxValue }">
+                 'progress-container--indeterminate': !lxProgress.lxValue }"
+     ng-style="lxProgress.getContainerProgressDimension()">
     <div class="progress-circular"
          ng-if="lxProgress.lxType === 'circular'"
          ng-style="lxProgress.getProgressDiameter()">


### PR DESCRIPTION
Image you have a circular progress with other object in the same line.
If you change the progress size (ex: 50px instead of 100px) you get this: 
![capture d ecran 2017-09-27 a 15 03 48](https://user-images.githubusercontent.com/6814372/30914946-879e70ba-a395-11e7-8484-7acbfcc7b7e4.png)

The `div.progress-container` size doesn't change. So I purpose to give a size to this div by a ng-style. 
By this way, the `div.progress-container` will have a 50px height / width and will have a correct alignment.

It might not be the perfect solution, I let you see.