### PR TITLE
 feat select: add a "panes" choices view mode

### DIFF
--- a/core/js/lumx.js
+++ b/core/js/lumx.js
@@ -6,12 +6,16 @@
     angular.module('lumx.utils.event-scheduler', []);
     angular.module('lumx.utils.transclude-replace', []);
     angular.module('lumx.utils.utils', []);
+    angular.module('lumx.utils.directives', []);
+    angular.module('lumx.utils.filters', []);
 
     angular.module('lumx.utils', [
         'lumx.utils.depth',
         'lumx.utils.event-scheduler',
         'lumx.utils.transclude-replace',
-        'lumx.utils.utils'
+        'lumx.utils.utils',
+        'lumx.utils.directives',
+        'lumx.utils.filters',
     ]);
 
     angular.module('lumx.button', []);

--- a/core/js/utils/misc.js
+++ b/core/js/utils/misc.js
@@ -1,0 +1,105 @@
+/* eslint-disable angular/component-limit */
+(function IIFE() {
+    'use strict';
+
+    /////////////////////////////
+
+    /**
+     * Highlights text in a string that matches another string.
+     *
+     * Taken from AngularUI Bootstrap Typeahead
+     * See https://github.com/angular-ui/bootstrap/blob/0.10.0/src/typeahead/typeahead.js#L340
+     */
+    HighlightFilter.$inject = ['LxUtils'];
+    function HighlightFilter(LxUtils) {
+        return function highlightCode(matchItem, query, html) {
+            if (!html) {
+                return (query && matchItem) ?
+                    matchItem.replace(
+                        new RegExp(LxUtils.escapeRegexp(query), 'gi'),
+                        '<span class="lx-select-choices__pane-choice--highlight">$&</span>'
+                    ) : matchItem;
+            }
+
+            var el = angular.element('<div>' + matchItem + '</div>');
+            if (el.children().length) {
+                angular.forEach(el.children(), function forEachNodes(node) {
+                    if (node.nodeName !== 'SPAN') {
+                        return;
+                    }
+
+                    var nodeEl = angular.element(node);
+                    nodeEl.html(highlightCode(nodeEl.text(), query, false))
+                });
+            } else {
+                el.html(highlightCode(el.text(), query, false));
+            }
+
+            return el.html();
+        };
+    }
+
+    /////////////////////////////
+
+    /**
+     * Replaces the markup `ng-include` with the included content.
+     *
+     * @return {Directive} The include-replace directive.
+     */
+    function IncludeReplaceDirective() {
+        return {
+            link: function includeReplaceLink(scope, el) {
+                el.replaceWith(el.children());
+            },
+            require: 'ngInclude',
+            restrict: 'A',
+        };
+    }
+
+    /////////////////////////////
+
+    /**
+     * Block any event propagation by adding the `prevent` attribute.
+     * Used to block the action of a link or a button for example.
+     *
+     * @return {Directive} The prevent directive.
+     */
+    function PreventDirective() {
+        return function preventCode(scope, el) {
+            el.on('click', function preventDefault(evt) {
+                evt.preventDefault();
+            });
+        };
+    }
+
+    /////////////////////////////
+
+    /**
+     * Blocks the propagation of an event in the DOM.
+     *
+     * @param  {string}    stopPropagation The name of the event (or events) to be stopped.
+     * @return {Directive} The stop propagation directive.
+     */
+    function StopPropagationDirective() {
+        return function stopPropagationCode(scope, el, attrs) {
+            el.on(attrs.stopPropagation, function stopPropagation(evt) {
+                evt.stopPropagation();
+            });
+        };
+    }
+
+    /////////////////////////////
+
+    /**
+     * Place here only small, highly re-usable directives.
+     * For a big complex directive, use a separate own file.
+     * For a directive specific to your application, place it in your application.
+     */
+    angular.module('lumx.utils.directives')
+        .directive('includeReplace', IncludeReplaceDirective)
+        .directive('prevent', PreventDirective)
+        .directive('stopPropagation', StopPropagationDirective);
+
+    angular.module('lumx.utils.filters')
+        .filter('highlight', HighlightFilter);
+})();

--- a/core/js/utils/utils_service.js
+++ b/core/js/utils/utils_service.js
@@ -11,8 +11,9 @@
         var service = this;
 
         service.debounce = debounce;
-        service.generateUUID = generateUUID;
         service.disableBodyScroll = disableBodyScroll;
+        service.escapeRegexp = escapeRegexp;
+        service.generateUUID = generateUUID;
 
         ////////////
 
@@ -73,21 +74,6 @@
             return debounced;
         }
 
-        function generateUUID()
-        {
-            var d = new Date().getTime();
-
-            var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c)
-            {
-                var r = (d + Math.random() * 16) % 16 | 0;
-                d = Math.floor(d / 16);
-                return (c == 'x' ? r : (r & 0x3 | 0x8))
-                    .toString(16);
-            });
-
-            return uuid.toUpperCase();
-        }
-
         function disableBodyScroll()
         {
             var body = document.body;
@@ -138,6 +124,31 @@
                 body.scrollTop = viewportTop;
               }
             };
+        }
+
+        /**
+         * Escape all RegExp special characters in a string.
+         *
+         * @param  {string} strToEscape The string to escape RegExp special char in.
+         * @return {string} The escapes string.
+         */
+        function escapeRegexp(strToEscape) {
+            return strToEscape.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
+        }
+
+        function generateUUID()
+        {
+            var d = new Date().getTime();
+
+            var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c)
+            {
+                var r = (d + Math.random() * 16) % 16 | 0;
+                d = Math.floor(d / 16);
+                return (c == 'x' ? r : (r & 0x3 | 0x8))
+                    .toString(16);
+            });
+
+            return uuid.toUpperCase();
         }
     }
 })();

--- a/demo/index.html
+++ b/demo/index.html
@@ -168,6 +168,7 @@
     <script src="/js/utils/event-scheduler_service.js"></script>
     <script src="/js/utils/transclude-replace_directive.js"></script>
     <script src="/js/utils/utils_service.js"></script>
+    <script src="/js/utils/misc.js"></script>
 
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -79,11 +79,11 @@
         }
     }
 
-    LxDropdownController.$inject = ['$element', '$interval', '$scope', '$timeout', '$window', 'LxDepthService',
-        'LxDropdownService', 'LxEventSchedulerService', 'LxUtils'
+    LxDropdownController.$inject = ['$element', '$interval', '$rootScope', '$scope', '$timeout', '$window',
+        'LxDepthService', 'LxDropdownService', 'LxEventSchedulerService', 'LxUtils'
     ];
 
-    function LxDropdownController($element, $interval, $scope, $timeout, $window, LxDepthService,
+    function LxDropdownController($element, $interval, $rootScope, $scope, $timeout, $window, LxDepthService,
         LxDropdownService, LxEventSchedulerService, LxUtils)
     {
         var lxDropdown = this;
@@ -145,6 +145,8 @@
 
         function closeDropdownMenu()
         {
+            $rootScope.$broadcast('lx-dropdown__close-start', $element.attr('id'));
+
             angular.element(window).off('resize', initDropdownPosition);
 
             $interval.cancel(dropdownInterval);
@@ -155,7 +157,6 @@
             var velocityEasing;
 
             scrollMask.remove();
-
             if (angular.isFunction(enableBodyScroll)) {
                 enableBodyScroll();
             }
@@ -237,6 +238,8 @@
                     idEventScheduler = undefined;
                 }
             }
+
+            $rootScope.$broadcast('lx-dropdown__close-end', $element.attr('id'));
         }
 
         function getAvailableHeight()
@@ -368,6 +371,8 @@
 
         function openDropdownMenu()
         {
+            $rootScope.$broadcast('lx-dropdown__open-start', $element.attr('id'));
+
             lxDropdown.isOpen = true;
 
             LxDepthService.register();
@@ -375,7 +380,6 @@
             scrollMask
                 .css('z-index', LxDepthService.getDepth())
                 .appendTo('body');
-
             scrollMask.on('wheel', function preventDefault(e) {
                 e.preventDefault();
             });
@@ -522,6 +526,8 @@
 
                     dropdownInterval = $interval(updateDropdownMenuHeight, 500);
                 }
+
+                $rootScope.$broadcast('lx-dropdown__open-end', $element.attr('id'));
             });
         }
 

--- a/modules/select/demo/includes/multipane.html
+++ b/modules/select/demo/includes/multipane.html
@@ -1,0 +1,32 @@
+<div class="p+ pt0">
+    <lx-select ng-model="vm.selectModel.selectedPeopleMultipane"
+               lx-allow-clear="true"
+               lx-choices="vm.selectPeopleMultipane"
+               lx-choices-view-mode="panes"
+               lx-display-filter="true"
+               lx-label="Lorem Ipsum Multipane">
+        <lx-select-selected>
+            #{{ $selected.uid }} - {{ $selected.name }}
+        </lx-select-selected>
+
+        <lx-select-choices>
+            {{ $choice.name }}
+        </lx-select-choices>
+    </lx-select>
+
+    <lx-select ng-model="vm.selectModel.selectedPeopleMultipaneMultiple"
+               lx-allow-clear="true"
+               lx-choices="vm.selectPeopleMultipane"
+               lx-choices-view-mode="panes"
+               lx-display-filter="true"
+               lx-label="Lorem Ipsum Multipane multiple"
+               lx-multiple="true">
+        <lx-select-selected>
+            #{{ $selected.uid }} - {{ $selected.name }}
+        </lx-select-selected>
+
+        <lx-select-choices>
+            {{ $choice.name }}
+        </lx-select-choices>
+    </lx-select>
+</div>

--- a/modules/select/demo/js/demo-select_controller.js
+++ b/modules/select/demo/js/demo-select_controller.js
@@ -164,6 +164,100 @@
                 type: 'Umbelliferous'
             }
         ];
+        vm.selectPeopleMultipane = {
+            '<i class="mdi mdi-human-male"></i> <span>Male</span>': {
+                'Old': [
+                    {
+                        uid: '1',
+                        name: 'Adam'
+                    },
+                    {
+                        uid: '2',
+                        name: 'Tom'
+                    },
+                    {
+                        uid: '3',
+                        name: 'Ben'
+                    }
+                ],
+                'Middle-aged': [
+                    {
+                        uid: '4',
+                        name: 'Franck'
+                    }
+                ],
+                'Young': [
+                    {
+                        uid: '5',
+                        name: 'Wladimir'
+                    },
+                    {
+                        uid: '6',
+                        name: 'Jack'
+                    }
+                ],
+            },
+            '<i class="mdi mdi-human-female"></i> <span>Female</span>': {
+                'France': {
+                    'Old': [
+                        {
+                            uid: '7',
+                            name: 'Amalie'
+                        }
+                    ],
+                    'Middle-aged': {
+                        'Lorem': [
+                            {
+                                uid: '8',
+                                name: 'Samantha'
+                            },
+                            {
+                                uid: '9',
+                                name: 'Estefanía'
+                            },
+                            {
+                                uid: '10',
+                                name: 'Natasha'
+                            },
+                            {
+                                uid: '11',
+                                name: 'Nicole'
+                            }
+                        ],
+                        'Ipsum': [
+                            {
+                                uid: '12',
+                                name: 'Julia'
+                            },
+                            {
+                                uid: '13',
+                                name: 'Sofia'
+                            }
+                        ],
+                    },
+                    'Young': [
+                        {
+                            uid: '14',
+                            name: 'Karin'
+                        },
+                        {
+                            uid: '15',
+                            name: 'Camillia'
+                        }
+                    ],
+                },
+                'US': [
+                    {
+                        uid: '16',
+                        name: 'Katerin'
+                    },
+                    {
+                        uid: '17',
+                        name: 'Olga'
+                    }
+                ],
+            }
+        };
         vm.newValueTransformer = function(_newValue) {
             return {
                 name: _newValue,
@@ -174,6 +268,8 @@
             selectedPerson: undefined,
             selectedPeople: [vm.selectPeople[2], vm.selectPeople[4]],
             selectedPeopleSections: [],
+            selectedPeopleMultipane: undefined,
+            selectedPeopleMultipaneMultiple: [],
             selectedVegetables: []
         };
 

--- a/modules/select/demo/select.html
+++ b/modules/select/demo/select.html
@@ -62,7 +62,7 @@
                     <td>Remove the LumX default style for select dropdown.</td>
                 </tr>
                 <tr>
-                    <td>lx-chocies-view-mode</td>
+                    <td>lx-choices-view-mode</td>
                     <td><code>string</code></td>
                     <td><code>list</code></td>
                     <td>The view mode of the choices. Options: <code>list</code>, <code>panes</code></td>

--- a/modules/select/demo/select.html
+++ b/modules/select/demo/select.html
@@ -11,6 +11,7 @@
     <lx-component lx-title="Theme" lx-path="/includes/modules/select/includes/theme.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
     <lx-component lx-title="View mode" lx-path="/includes/modules/select/includes/view-mode.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
     <lx-component lx-title="Autocomplete" lx-path="/includes/modules/select/includes/autocomplete.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
+    <lx-component lx-title="Multipane" lx-path="/includes/modules/select/includes/multipane.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
 
     <lx-component-attributes>
         <table>
@@ -59,6 +60,12 @@
                     <td><code>boolean</code></td>
                     <td><code>false</code></td>
                     <td>Remove the LumX default style for select dropdown.</td>
+                </tr>
+                <tr>
+                    <td>lx-chocies-view-mode</td>
+                    <td><code>string</code></td>
+                    <td><code>list</code></td>
+                    <td>The view mode of the choices. Options: <code>list</code>, <code>panes</code></td>
                 </tr>
                 <tr>
                     <td>lx-custom-style</td>
@@ -148,7 +155,7 @@
                     <td>lx-view-mode</td>
                     <td><code>string</code></td>
                     <td><code>field</code></td>
-                    <td>The select component view mode. Options: field, chips</td>
+                    <td>The select component view mode. Options: <code>field</code>, <code>chips</code></td>
                 </tr>
                 <tr>
                     <td>ng-change</td>

--- a/modules/select/scss/_select.scss
+++ b/modules/select/scss/_select.scss
@@ -172,6 +172,10 @@
     .lx-select--default-style:not(.lx-select--autocomplete) .dropdown--is-open &:after {
         @include mdi-icon('menu-up');
     }
+
+    & > .lx-select-selected__filter {
+        display: none;
+    }
 }
 
 .lx-select-selected {
@@ -360,6 +364,10 @@
         }
     }
 
+    .lx-select-selected--multipane {
+        position: relative;
+    }
+
 
 
 
@@ -474,3 +482,122 @@
         @include flex-direction(row);
         @include justify-content(center);
     }
+
+    .lx-select-choices--multi-panes {
+        width: auto !important;
+        overflow: hidden !important;
+
+        .dropdown-menu__content {
+            padding: 0;
+        }
+    }
+
+    .lx-select-choices__panes-container {
+        @include display(flex);
+        @include flex-direction(row);
+    }
+
+    .lx-select-choices__pane {
+        @include position(relative);
+        padding: $base-spacing-unit 0;
+
+        &-choice {
+            @include display(flex);
+            height: $base-spacing-unit * 10;
+            min-width: 120px;
+            line-height: $base-spacing-unit * 10;
+            margin-left: $base-spacing-unit * 2;
+            padding: 0 $base-spacing-unit * 3 0 $base-spacing-unit * 2;
+            color: $white;
+            cursor: pointer;
+
+            i {
+                @include font-size(40px);
+            }
+
+            span:not(.lx-select-choices__pane-choice--highlight) {
+                @include flex(1);
+            }
+
+            &:hover {
+                background-color: $white;
+                color: $black;
+                font-weight: bold;
+            }
+
+            &--highlight {
+                font-weight: bold;
+                text-decoration: underline;
+                text-decoration-skip: ink;
+            }
+        }
+
+        &.lx-select-choices__pane--first {
+            .lx-select-choices__pane-choice {
+                margin-left: 0;
+            }
+        }
+
+        &.lx-select-choices__pane--is-filtering {
+            .lx-select-choices__pane-choice {
+                opacity: 0.3;
+
+                &--is-matching {
+                    opacity: 1;
+                }
+            }
+        }
+
+        @for $i from 2 through 7 {
+            &-#{$i - 2} {
+                @extend .bgc-grey-#{1000 - (($i + 1) * 100)};
+
+                & .lx-select-choices__pane-choice {
+                    @if $i >= 5 {
+                        color: $black;
+                    }
+
+                    &--is-selected {
+                        @extend .bgc-grey-#{1000 - (($i + 2) * 100)};
+                    }
+                }
+            }
+
+        }
+    }
+
+
+
+
+
+.lx-select--panes.lx-select--with-filter {
+    .lx-select-selected-wrapper.lx-select-selected-wrapper--with-filter {
+        @include display(flex);
+        min-height: $base-spacing-unit * 5 !important;
+
+        .lx-select-selected__value {
+            margin-right: $base-spacing-unit;
+            line-height: $base-spacing-unit * 5 !important;
+        }
+
+        .lx-select-selected__tag:last-child {
+            margin-right: $base-spacing-unit;
+        }
+
+        .lx-select-selected__filter {
+            @include display(block);
+            @include flex(1);
+            margin-top: $base-spacing-unit;
+            margin-bottom: $base-spacing-unit / 2;
+            margin-right: $base-spacing-unit;
+            min-height: $base-spacing-unit * 5 !important;
+            line-height: $base-spacing-unit * 5 !important;
+        }
+    }
+
+    &:not(.lx-select--is-active) {
+        .lx-select-label {
+            line-height: $base-spacing-unit * 5 !important;
+        }
+    }
+}

--- a/modules/select/scss/_select.scss
+++ b/modules/select/scss/_select.scss
@@ -503,9 +503,9 @@
 
         &-choice {
             @include display(flex);
-            height: $base-spacing-unit * 10;
+            height: $base-spacing-unit * 7;
             min-width: 120px;
-            line-height: $base-spacing-unit * 10;
+            line-height: $base-spacing-unit * 7;
             margin-left: $base-spacing-unit * 2;
             padding: 0 $base-spacing-unit * 3 0 $base-spacing-unit * 2;
             color: $white;

--- a/modules/select/views/select-choices.html
+++ b/modules/select/views/select-choices.html
@@ -2,14 +2,16 @@
                   ng-class="{ 'lx-select-choices--custom-style': lxSelectChoices.parentCtrl.choicesCustomStyle,
                               'lx-select-choices--default-style': !lxSelectChoices.parentCtrl.choicesCustomStyle,
                               'lx-select-choices--is-multiple': lxSelectChoices.parentCtrl.multiple,
-                              'lx-select-choices--is-unique': !lxSelectChoices.parentCtrl.multiple, }">
-    <ul>
+                              'lx-select-choices--is-unique': !lxSelectChoices.parentCtrl.multiple,
+                              'lx-select-choices--list': lxSelectChoices.parentCtrl.choicesViewMode === 'list',
+                              'lx-select-choices--multi-panes': lxSelectChoices.parentCtrl.choicesViewMode === 'panes' }">
+    <ul ng-if="::lxSelectChoices.parentCtrl.choicesViewMode === 'list'">
         <li class="lx-select-choices__filter" ng-if="::lxSelectChoices.parentCtrl.displayFilter && !lxSelectChoices.parentCtrl.autocomplete">
             <lx-search-filter lx-dropdown-filter>
                 <input type="text" ng-model="lxSelectChoices.parentCtrl.filterModel" ng-change="lxSelectChoices.parentCtrl.updateFilter()">
             </lx-search-filter>
         </li>
-        
+
         <div ng-if="::lxSelectChoices.isArray()">
             <li class="lx-select-choices__choice"
                 ng-class="{ 'lx-select-choices__choice--is-selected': lxSelectChoices.parentCtrl.isSelected(choice),
@@ -41,4 +43,22 @@
             <lx-progress lx-type="circular" lx-color="primary" lx-diameter="20"></lx-progress>
         </li>
     </ul>
+
+    <div ng-if="::lxSelectChoices.parentCtrl.choicesViewMode === 'panes'" stop-propagation="click">
+        <div class="lx-select-choices__panes-container">
+            <div class="lx-select-choices__pane lx-select-choices__pane-{{ $index }}"
+                 ng-class="{ 'lx-select-choices__pane--is-filtering': lxSelectChoices.parentCtrl.matchingPaths !== undefined,
+                             'lx-select-choices__pane--first': $first,
+                             'lx-select-choices__pane--last': $last }"
+                 ng-repeat="pane in lxSelectChoices.parentCtrl.panes">
+                <div ng-repeat="(label, items) in pane"
+                   class="lx-select-choices__pane-choice"
+                   ng-class="{ 'lx-select-choices__pane-choice--is-selected': lxSelectChoices.parentCtrl.isPaneToggled($parent.$index, label) || lxSelectChoices.parentCtrl.isSelected(items),
+                               'lx-select-choices__pane-choice--is-matching': lxSelectChoices.parentCtrl.isMatchingPath($parent.$index, label) }"
+                   ng-bind-html="(lxSelectChoices.isArray(pane)) ? lxSelectChoices.parentCtrl.displayChoice(items) : lxSelectChoices.parentCtrl.displaySubheader(label)"
+                   ng-click="lxSelectChoices.parentCtrl.togglePane($event, $parent.$index, label, true)">
+                </div>
+            </div>
+        </div>
+    </div>
 </lx-dropdown-menu>

--- a/modules/select/views/select-selected-content.html
+++ b/modules/select/views/select-selected-content.html
@@ -1,11 +1,15 @@
-<div class="lx-select-selected-wrapper" id="lx-select-selected-wrapper-{{ lxSelectSelected.parentCtrl.uuid }}">
-    <div class="lx-select-selected" ng-if="!lxSelectSelected.parentCtrl.multiple && lxSelectSelected.parentCtrl.getSelectedModel()">
+<div class="lx-select-selected-wrapper"
+     ng-class="{ 'lx-select-selected-wrapper--with-filter': !lxSelectSelected.parentCtrl.ngDisabled && lxSelectSelected.parentCtrl.areChoicesOpened() && (lxSelectSelected.parentCtrl.multiple || !lxSelectSelected.parentCtrl.getSelectedModel()) }"
+     id="lx-select-selected-wrapper-{{ lxSelectSelected.parentCtrl.uuid }}">
+    <div class="lx-select-selected"
+         ng-if="!lxSelectSelected.parentCtrl.multiple">
         <span class="lx-select-selected__value"
-              ng-bind-html="lxSelectSelected.parentCtrl.displaySelected()"></span>
+              ng-bind-html="lxSelectSelected.parentCtrl.displaySelected()"
+              ng-if="lxSelectSelected.parentCtrl.getSelectedModel()"></span>
 
         <a class="lx-select-selected__clear"
            ng-click="lxSelectSelected.clearModel($event)"
-           ng-if="::lxSelectSelected.parentCtrl.allowClear">
+           ng-if="lxSelectSelected.parentCtrl.allowClear && lxSelectSelected.parentCtrl.getSelectedModel()">
             <i class="mdi mdi-close-circle"></i>
         </a>
     </div>
@@ -23,6 +27,14 @@
                ng-model="lxSelectSelected.parentCtrl.filterModel"
                ng-change="lxSelectSelected.parentCtrl.updateFilter()"
                ng-keydown="lxSelectSelected.parentCtrl.keyEvent($event)"
-               ng-if="::lxSelectSelected.parentCtrl.autocomplete && !lxSelectSelected.parentCtrl.ngDisabled">
+               ng-if="lxSelectSelected.parentCtrl.autocomplete && !lxSelectSelected.parentCtrl.ngDisabled">
     </div>
+
+    <lx-search-filter lx-dropdown-filter class="lx-select-selected__filter">
+        <input type="text"
+               ng-model="lxSelectSelected.parentCtrl.filterModel"
+               ng-change="lxSelectSelected.parentCtrl.updateFilter()"
+               ng-keydown="lxSelectSelected.parentCtrl.keyEvent($event)"
+               stop-propagation="click">
+    </lx-search-filter>
 </div>

--- a/modules/select/views/select.html
+++ b/modules/select/views/select.html
@@ -1,7 +1,7 @@
 <div class="lx-select"
      ng-class="{ 'lx-select--error': lxSelect.error,
                  'lx-select--fixed-label': lxSelect.fixedLabel && lxSelect.viewMode === 'field',
-                 'lx-select--is-active': (!lxSelect.multiple && lxSelect.getSelectedModel()) || (lxSelect.multiple && lxSelect.getSelectedModel().length),
+                 'lx-select--is-active': (!lxSelect.multiple && lxSelect.getSelectedModel()) || (lxSelect.multiple && lxSelect.getSelectedModel().length) || (lxSelect.choicesViewMode === 'panes' && lxSelect.areChoicesOpened()),
                  'lx-select--is-disabled': lxSelect.ngDisabled,
                  'lx-select--is-multiple': lxSelect.multiple,
                  'lx-select--is-unique': !lxSelect.multiple,
@@ -12,12 +12,15 @@
                  'lx-select--default-style': !lxSelect.customStyle,
                  'lx-select--view-mode-field': !lxSelect.multiple || (lxSelect.multiple && lxSelect.viewMode === 'field'),
                  'lx-select--view-mode-chips': lxSelect.multiple && lxSelect.viewMode === 'chips',
+                 'lx-select--panes': lxSelect.choicesViewMode === 'panes',
+                 'lx-select--with-filter': lxSelect.displayFilter,
                  'lx-select--autocomplete': lxSelect.autocomplete }">
     <span class="lx-select-label" ng-if="!lxSelect.autocomplete">
         {{ lxSelect.label }}
     </span>
 
-    <lx-dropdown id="dropdown-{{ lxSelect.uuid }}" lx-width="100%" lx-effect="{{ lxSelect.autocomplete ? 'none' : 'expand' }}">
+    <lx-dropdown id="dropdown-{{ lxSelect.uuid }}" lx-width="{{ (lxSelect.choicesViewMode === 'panes') ? '' : '100%' }}"
+                 lx-effect="{{ lxSelect.autocomplete ? 'none' : 'expand' }}">
         <ng-transclude></ng-transclude>
     </lx-dropdown>
 </div>


### PR DESCRIPTION
This view mode allow to display multiple panes for selecting choices.
The choices must be provided according to a specific data model.
If filter is enable, then it will perform a search through the path of
the panes to search for matching items. Matching items will be
highlighted and containing panes will be auto-opened.

For more information regarding this view mode, see the examples