### PR TITLE
fix dropdown: make the dropdown scrollable

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -87,7 +87,7 @@
         LxDropdownService, LxEventSchedulerService, LxUtils)
     {
         var lxDropdown = this;
-        var dropdownInterval;
+        var dropdownContentWatcher;
         var dropdownMenu;
         var dropdownToggle;
         var idEventScheduler;
@@ -149,7 +149,10 @@
 
             angular.element(window).off('resize', initDropdownPosition);
 
-            $interval.cancel(dropdownInterval);
+            if (angular.isFunction(dropdownContentWatcher)) {
+                dropdownContentWatcher();
+                dropdownContentWatcher = undefined;
+            }
 
             LxDropdownService.resetActiveDropdownUuid();
 
@@ -173,7 +176,6 @@
             }
 
             dropdownMenu
-                .off('wheel')
                 .css(
                 {
                     overflow: 'hidden'
@@ -404,19 +406,6 @@
                 .css('z-index', LxDepthService.getDepth() + 1)
                 .appendTo('body');
 
-            dropdownMenu.on('wheel', function preventDefault(e) {
-                var d = e.originalEvent.deltaY;
-
-                if (d < 0 && dropdownMenu.scrollTop() === 0) {
-                    e.preventDefault();
-                }
-                else {
-                    if (d > 0 && (dropdownMenu.scrollTop() == dropdownMenu.get(0).scrollHeight - dropdownMenu.innerHeight())) {
-                        e.preventDefault();
-                    }
-                }
-            });
-
             if (lxDropdown.escapeClose)
             {
                 idEventScheduler = LxEventSchedulerService.register('keyup', onKeyUp);
@@ -434,6 +423,21 @@
                     enoughHeight = false;
                     dropdownMenuHeight = availableHeight;
                 }
+
+                /*
+                 * Watch for any changes in the dropdown content.
+                 * Each time the content of the dropdown changes, recompute its height to be sure to stay inside of the
+                 * viewport (and make it scrollable when it overflows).
+                 */
+                dropdownContentWatcher = $scope.$watch(function watcherDropdownContent() {
+                    return dropdownMenu.find('.dropdown-menu__content').html();
+                }, function watchDropdownContent(newValue, oldValue) {
+                    if (newValue === oldValue) {
+                        return;
+                    }
+
+                    updateDropdownMenuHeight();
+                })
 
                 if (lxDropdown.effect === 'expand')
                 {
@@ -487,8 +491,6 @@
                             $timeout(updateDropdownMenuHeight);
 
                             dropdownMenu.find('.dropdown-menu__content').removeAttr('style');
-
-                            dropdownInterval = $interval(updateDropdownMenuHeight, 500);
                         }
                     });
                 }
@@ -510,8 +512,6 @@
                         complete: function()
                         {
                             $timeout(updateDropdownMenuHeight);
-
-                            dropdownInterval = $interval(updateDropdownMenuHeight, 500);
                         }
                     });
                 }
@@ -523,8 +523,6 @@
                     });
 
                     $timeout(updateDropdownMenuHeight);
-
-                    dropdownInterval = $interval(updateDropdownMenuHeight, 500);
                 }
 
                 $rootScope.$broadcast('lx-dropdown__open-end', $element.attr('id'));
@@ -568,10 +566,14 @@
             }
         }
 
-        function updateDropdownMenuHeight()
-        {
-            if (positionTarget)
-            {
+        /**
+         * Update the height of the dropdown.
+         * If the content is too large to fit in the remaining size of the screen (to the top or the bottom), then make
+         * it scrollable.
+         * This function is called everytime the content inside of the dropdown changes.
+         */
+        function updateDropdownMenuHeight() {
+            if (positionTarget) {
                 registerDropdownToggle(angular.element(positionTarget));
             }
 
@@ -580,44 +582,32 @@
             }
 
             var availableHeight = getAvailableHeight();
+
+            dropdownMenu.css({
+                height: 'auto',
+            });
+            dropdownMenu.css(availableHeight.direction, 'auto');
+
             var dropdownMenuHeight = dropdownMenu.find('.dropdown-menu__content').outerHeight();
 
-            dropdownMenu.css(
-            {
-                height: 'auto'
-            });
-
-            if ((availableHeight[availableHeight.direction] - ~~lxDropdown.offset) < dropdownMenuHeight)
-            {
-                if (availableHeight.direction === 'top')
-                {
-                    dropdownMenu.css(
-                    {
-                        top: 0
+            if ((availableHeight[availableHeight.direction] - ~~lxDropdown.offset) <= dropdownMenuHeight) {
+                if (availableHeight.direction === 'top') {
+                    dropdownMenu.css({
+                        top: 0,
+                    });
+                } else if (availableHeight.direction === 'bottom') {
+                    dropdownMenu.css({
+                        bottom: 0,
                     });
                 }
-                else if (availableHeight.direction === 'bottom')
-                {
-                    dropdownMenu.css(
-                    {
-                        bottom: 0
+            } else {
+                if (availableHeight.direction === 'top') {
+                    dropdownMenu.css({
+                        top: 'auto',
                     });
-                }
-            }
-            else
-            {
-                if (availableHeight.direction === 'top')
-                {
-                    dropdownMenu.css(
-                    {
-                        top: 'auto'
-                    });
-                }
-                else if (availableHeight.direction === 'bottom')
-                {
-                    dropdownMenu.css(
-                    {
-                        bottom: 'auto'
+                } else if (availableHeight.direction === 'bottom') {
+                    dropdownMenu.css({
+                        bottom: 'auto',
                     });
                 }
             }

--- a/modules/dropdown/scss/_dropdown.scss
+++ b/modules/dropdown/scss/_dropdown.scss
@@ -45,6 +45,7 @@
     .dropdown-menu__content {
         padding: $base-spacing-unit 0;
         opacity: 0;
+        height: 100%;
         @include transition-property(opacity);
         @include transition-duration(0.2s);
 


### PR DESCRIPTION
If the content of the dropdown is to big to fit in the remaining of the
screen (to the top or the bottom according to the position of the target
of the dropdown), then make it scrollable.

Also, improve the recomputation of the height of the dropdown. Watch the
changes of the content instead of using an interval.