### PR TITLE
fix(select-multi-panes): fix text superposition in responsive mode

### DIFF
--- a/modules/select/demo/select.html
+++ b/modules/select/demo/select.html
@@ -1,5 +1,4 @@
 <div class="main-section">
-    <lx-component lx-title="Multipane" lx-path="/includes/modules/select/includes/multipane.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
     <h1 class="main-section__title">Select</h1>
 
     <p class="main-section__intro">
@@ -12,6 +11,7 @@
     <lx-component lx-title="Theme" lx-path="/includes/modules/select/includes/theme.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
     <lx-component lx-title="View mode" lx-path="/includes/modules/select/includes/view-mode.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
     <lx-component lx-title="Autocomplete" lx-path="/includes/modules/select/includes/autocomplete.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
+    <lx-component lx-title="Multipane" lx-path="/includes/modules/select/includes/multipane.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
 
     <lx-component-attributes>
         <table>

--- a/modules/select/demo/select.html
+++ b/modules/select/demo/select.html
@@ -1,4 +1,5 @@
 <div class="main-section">
+    <lx-component lx-title="Multipane" lx-path="/includes/modules/select/includes/multipane.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
     <h1 class="main-section__title">Select</h1>
 
     <p class="main-section__intro">
@@ -11,7 +12,6 @@
     <lx-component lx-title="Theme" lx-path="/includes/modules/select/includes/theme.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
     <lx-component lx-title="View mode" lx-path="/includes/modules/select/includes/view-mode.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
     <lx-component lx-title="Autocomplete" lx-path="/includes/modules/select/includes/autocomplete.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
-    <lx-component lx-title="Multipane" lx-path="/includes/modules/select/includes/multipane.html" lx-js-path="/js/select/demo/demo-select_controller.js"></lx-component>
 
     <lx-component-attributes>
         <table>

--- a/modules/select/scss/_select.scss
+++ b/modules/select/scss/_select.scss
@@ -509,9 +509,8 @@
         overflow: auto;
 
         &-choice {
-            height: $base-spacing-unit * 7;
+            min-height: $base-spacing-unit * 7;
             min-width: 120px;
-            line-height: $base-spacing-unit * 7;
             margin-left: $base-spacing-unit * 2;
             padding: 0 $base-spacing-unit * 3 0 $base-spacing-unit * 2;
             color: $white;
@@ -538,7 +537,12 @@
             }
 
             @include mq($until: desktop) {
-                padding: 0 $base-spacing-unit * 5 0 $base-spacing-unit * 2;
+                position: relative;
+                padding: $base-spacing-unit * 2 $base-spacing-unit * 5 $base-spacing-unit * 2 $base-spacing-unit * 2;
+
+                span {
+                    padding: 17px 0 17px 0;
+                }
 
                 &:not(.lx-select-choices__pane-choice--is-leaf) {
                     &:after {
@@ -547,6 +551,8 @@
                         @include mdi-icon('chevron-down');
                         @include font-size(20px);
                         right: 10px;
+                        top: 50%;
+                        transform: translateY(-50%);
                     }
 
                     &.lx-select-choices__pane-choice--is-selected {

--- a/modules/select/scss/_select.scss
+++ b/modules/select/scss/_select.scss
@@ -505,29 +505,25 @@
 
     .lx-select-choices__pane {
         @include position(relative);
-        padding: $base-spacing-unit 0;
         overflow: auto;
 
         &-choice {
-            min-height: $base-spacing-unit * 7;
+            @include display(flex);
+            @include align-items(center);
             min-width: 120px;
-            margin-left: $base-spacing-unit * 2;
-            padding: 0 $base-spacing-unit * 3 0 $base-spacing-unit * 2;
+            margin:$base-spacing-unit 0 $base-spacing-unit $base-spacing-unit * 1.5;
+            padding: $base-spacing-unit * 1.5;
             color: $white;
             cursor: pointer;
 
             i {
                 @include font-size(40px);
+                line-height:40px;
+                margin-right: $base-spacing-unit;
             }
 
             span:not(.lx-select-choices__pane-choice--highlight) {
                 @include flex(1);
-            }
-
-            &:hover {
-                background-color: $white;
-                color: $black;
-                font-weight: bold;
             }
 
             &--highlight {
@@ -536,23 +532,25 @@
                 text-decoration-skip: ink;
             }
 
+            @include mq($from: desktop) {
+                &:hover {
+                    background-color: $white;
+                    color: $black;
+                }
+            }
+
             @include mq($until: desktop) {
                 position: relative;
-                padding: $base-spacing-unit * 2 $base-spacing-unit * 5 $base-spacing-unit * 2 $base-spacing-unit * 2;
-
-                span {
-                    padding: 17px 0 17px 0;
-                }
+                padding: $base-spacing-unit * 1.5;
 
                 &:not(.lx-select-choices__pane-choice--is-leaf) {
                     &:after {
-                        position: absolute;
+                        justify-self:flex-end;
                         @include mdi;
                         @include mdi-icon('chevron-down');
                         @include font-size(20px);
-                        right: 10px;
-                        top: 50%;
-                        transform: translateY(-50%);
+                        margin-left: auto;
+                        padding-left: $base-spacing-unit;
                     }
 
                     &.lx-select-choices__pane-choice--is-selected {
@@ -566,8 +564,7 @@
 
         &.lx-select-choices__pane--first {
             .lx-select-choices__pane-choice {
-                @include display(flex);
-                margin-left: 0;
+                margin: 0;
             }
         }
 


### PR DESCRIPTION
Fix the text suprposition problem when pane content is too long to be displayed in one line.