### PR TITLE
fix: remove unused misc directives and rename other

### DIFF
--- a/core/js/utils/misc.js
+++ b/core/js/utils/misc.js
@@ -42,39 +42,6 @@
     /////////////////////////////
 
     /**
-     * Replaces the markup `ng-include` with the included content.
-     *
-     * @return {Directive} The include-replace directive.
-     */
-    function IncludeReplaceDirective() {
-        return {
-            link: function includeReplaceLink(scope, el) {
-                el.replaceWith(el.children());
-            },
-            require: 'ngInclude',
-            restrict: 'A',
-        };
-    }
-
-    /////////////////////////////
-
-    /**
-     * Block any event propagation by adding the `prevent` attribute.
-     * Used to block the action of a link or a button for example.
-     *
-     * @return {Directive} The prevent directive.
-     */
-    function PreventDirective() {
-        return function preventCode(scope, el) {
-            el.on('click', function preventDefault(evt) {
-                evt.preventDefault();
-            });
-        };
-    }
-
-    /////////////////////////////
-
-    /**
      * Blocks the propagation of an event in the DOM.
      *
      * @param  {string}    stopPropagation The name of the event (or events) to be stopped.
@@ -96,10 +63,8 @@
      * For a directive specific to your application, place it in your application.
      */
     angular.module('lumx.utils.directives')
-        .directive('includeReplace', IncludeReplaceDirective)
-        .directive('prevent', PreventDirective)
-        .directive('stopPropagation', StopPropagationDirective);
+        .directive('lxStopPropagation', StopPropagationDirective);
 
     angular.module('lumx.utils.filters')
-        .filter('highlight', HighlightFilter);
+        .filter('lxHighlight', HighlightFilter);
 })();

--- a/modules/select/js/select_directive.js
+++ b/modules/select/js/select_directive.js
@@ -597,7 +597,7 @@
 
             var interpolatedChoice = $interpolate(choiceTemplate)(choiceScope);
             return $sce.trustAsHtml((lxSelect.matchingPaths) ?
-                $filter('highlight')(interpolatedChoice, lxSelect.filterModel, true) : interpolatedChoice
+                $filter('lxHighlight')(interpolatedChoice, lxSelect.filterModel, true) : interpolatedChoice
             );
         }
 
@@ -648,7 +648,7 @@
         function displaySubheader(_subheader)
         {
             return $sce.trustAsHtml((lxSelect.matchingPaths) ?
-                $filter('highlight')(_subheader, lxSelect.filterModel, true) : _subheader
+                $filter('lxHighlight')(_subheader, lxSelect.filterModel, true) : _subheader
             );
         }
 

--- a/modules/select/views/select-choices.html
+++ b/modules/select/views/select-choices.html
@@ -44,7 +44,7 @@
         </li>
     </ul>
 
-    <div class="lx-select-choices__panes-wrapper" ng-if="lxSelectChoices.parentCtrl.choicesViewMode === 'panes' && lxSelectChoices.parentCtrl.choicesViewSize === 'large'" stop-propagation="click">
+    <div class="lx-select-choices__panes-wrapper" ng-if="lxSelectChoices.parentCtrl.choicesViewMode === 'panes' && lxSelectChoices.parentCtrl.choicesViewSize === 'large'" lx-stop-propagation="click">
         <div class="lx-select-choices__loader" ng-if="lxSelectChoices.parentCtrl.loading">
             <lx-progress lx-type="circular" lx-color="white" lx-diameter="60"></lx-progress>
         </div>
@@ -67,7 +67,7 @@
         </div>
     </div>
 
-    <div class="lx-select-choices__panes-wrapper" ng-if="lxSelectChoices.parentCtrl.choicesViewMode === 'panes' && lxSelectChoices.parentCtrl.choicesViewSize === 'small'" stop-propagation="click">
+    <div class="lx-select-choices__panes-wrapper" ng-if="lxSelectChoices.parentCtrl.choicesViewMode === 'panes' && lxSelectChoices.parentCtrl.choicesViewSize === 'small'" lx-stop-propagation="click">
         <div class="lx-select-choices__loader" ng-if="lxSelectChoices.parentCtrl.loading">
             <lx-progress lx-type="circular" lx-color="white" lx-diameter="60"></lx-progress>
         </div>

--- a/modules/select/views/select-selected-content.html
+++ b/modules/select/views/select-selected-content.html
@@ -34,6 +34,6 @@
         <input type="text"
                ng-model="lxSelectSelected.parentCtrl.filterModel"
                ng-change="lxSelectSelected.parentCtrl.updateFilter()"
-               stop-propagation="click">
+               lx-stop-propagation="click">
     </lx-search-filter>
 </div>


### PR DESCRIPTION
This way, there is no chances of conflict with other libs

BROKEN:
The `stopPropagation` directive has been renamed to `lxStopPropagation`
The `highlight` filter has been renamed to `lxHighlight`