### PR TITLE
fix dropdown: content height not recomputed correctly when it changes…

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -583,6 +583,9 @@
 
             var availableHeight = getAvailableHeight();
 
+            dropdownMenu.css({
+                height: 'auto',
+            });
             dropdownMenu.css(availableHeight.direction, 'auto');
 
             var dropdownMenuHeight = dropdownMenu.find('.dropdown-menu__content').outerHeight();


### PR DESCRIPTION
… quickly

partial rollback of 4c8557b7c77fa3571fe9b963e837ec4a152c9af1

If you change the content of the dropdown while it's calculating its size (for ex because of some ng-if in the content of your dropdown), then it is displayed incorrectly.