### PR TITLE
fix(lx-select): be able to select an item after scroll

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -780,9 +780,9 @@
         }
     }
 
-    lxDropdownFilter.$inject = ['$timeout'];
+    lxDropdownFilter.$inject = ['$timeout', '$window'];
 
-    function lxDropdownFilter($timeout)
+    function lxDropdownFilter($timeout, $window)
     {
         return {
             restrict: 'A',
@@ -791,7 +791,10 @@
 
         function link(scope, element)
         {
+            var filterHasFocus = false;
             var focusTimeout;
+            var input = element.find('input');
+            var currentWindow = angular.element($window);
 
             element.on('click', function(_event)
             {
@@ -800,13 +803,21 @@
 
             focusTimeout = $timeout(function()
             {
-                element.find('input').focus();
+                input.focus();
+                filterHasFocus = true;
             }, 200);
+
+            window.on('mousewheel', function onMousewheel() {
+                if (selectIsFocus) {
+                    input.blur();
+                }
+            });
 
             scope.$on('$destroy', function()
             {
                 $timeout.cancel(focusTimeout);
                 element.off();
+                currentWindow.off('mousewheel');
             });
         }
     }

--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -807,9 +807,12 @@
                 filterHasFocus = true;
             }, 200);
 
-            window.on('mousewheel', function onMousewheel() {
-                if (selectIsFocus) {
+            currentWindow.on('mousewheel', function onMousewheel()
+            {
+                if (filterHasFocus)
+                {
                     input.blur();
+                    currentWindow.off('mousewheel');
                 }
             });
 
@@ -817,7 +820,11 @@
             {
                 $timeout.cancel(focusTimeout);
                 element.off();
-                currentWindow.off('mousewheel');
+                
+                if (filterHasFocus)
+                {
+                    currentWindow.off('mousewheel');
+                }
             });
         }
     }


### PR DESCRIPTION
When you have a lx-select with a filter, you can't select an item that you see after a scroll in the select. The directive thinks you had clicked out the select (the ng-click of the item is not triggered).

The origin of this bug is the focus on the input. So I blur it when you scroll this the mousewheel in the select (you can't scroll with arrows because the input has the focus and if you click on the scrollbar you focus the right element).

**Step to reproduce**

1. Have a lx-select with enough element to have a scroll and enable the filter and multiple mode.
2. Open the select, you can select a visible item.
3. If you select a visible item, you can scroll and select a new item (= an item which was not visible before you scrolled) because the click on the first item has focused the right element
4. Close the select
5. Open it again, scroll and try to select a new visible element, you can't, the select just closes itself.

With the fix : 
The mousewheel scroll blur the filter input and you can select a new item.