### PR TITLE
fix(dropdown-scroll): removing body scroll bug for nested dropdown

### DIFF
--- a/core/js/utils/utils_service.js
+++ b/core/js/utils/utils_service.js
@@ -80,7 +80,7 @@
             var body = document.body;
             var documentElement = document.documentElement;
 
-            if(!alreadyDisabledScroll) {
+            if (!alreadyDisabledScroll) {
                 var prevDocumentStyle = documentElement.style.cssText || '';
                 var prevBodyStyle = body.style.cssText || '';
                 var viewportTop = (document.scrollingElement) ?

--- a/core/js/utils/utils_service.js
+++ b/core/js/utils/utils_service.js
@@ -9,6 +9,7 @@
     function LxUtils()
     {
         var service = this;
+        var alreadyDisabledScroll = false;
 
         service.debounce = debounce;
         service.disableBodyScroll = disableBodyScroll;
@@ -79,12 +80,14 @@
             var body = document.body;
             var documentElement = document.documentElement;
 
-            var prevDocumentStyle = documentElement.style.cssText || '';
-            var prevBodyStyle = body.style.cssText || '';
+            if(!alreadyDisabledScroll) {
+                var prevDocumentStyle = documentElement.style.cssText || '';
+                var prevBodyStyle = body.style.cssText || '';
+                var viewportTop = (document.scrollingElement) ?
+                    document.scrollingElement.scrollTop : window.scrollY || window.pageYOffset || body.scrollTop;
+                viewportTop = viewportTop || 0;
+            }
 
-            var viewportTop = (document.scrollingElement) ?
-                document.scrollingElement.scrollTop : window.scrollY || window.pageYOffset || body.scrollTop;
-            viewportTop = viewportTop || 0;
 
             var clientWidth = body.clientWidth;
             var hasVerticalScrollbar = body.scrollHeight > window.innerHeight + 1;
@@ -111,18 +114,28 @@
               documentElement.style.overflowY = 'scroll';
             }
 
+            // This attribution prevents this function to consider the css it sets
+            // to body and documents to be the 'previous' css attributes to recover.
+            alreadyDisabledScroll = true;
+
             return function restoreScroll()
             {
-              // Reset the inline style CSS to the previous.
-              body.style.cssText = prevBodyStyle;
-              documentElement.style.cssText = prevDocumentStyle;
+                if (!alreadyDisabledScroll) {
+                    return;
+                }
 
-              // The body loses its scroll position while being fixed.
-              if (document.scrollingElement) {
-                document.scrollingElement.scrollTop = viewportTop;
-              } else {
-                body.scrollTop = viewportTop;
-              }
+                // Reset the inline style CSS to the previous.
+                body.style.cssText = prevBodyStyle;
+                documentElement.style.cssText = prevDocumentStyle;
+                
+                // The body loses its scroll position while being fixed.
+                if (document.scrollingElement) {
+                    document.scrollingElement.scrollTop = viewportTop;
+                } else {
+                    body.scrollTop = viewportTop;
+                }
+
+                alreadyDisabledScroll = false;
             };
         }
 


### PR DESCRIPTION
## General summary

This PR fixes the scroll bug when we are using nested `lx-dropdown` 

## Test scenario
0. Be sure your page is wide enough, you should be able to scroll on Y axis
1. Set nested dropdown in a page
2. Open all the dropdowns
3. When clicking away, the dropdowns are closing
4. You should be able to scroll again and the window in not auto scrolling to the top