### PR TITLE
fix tabs: only display none by default for separate layout

### DIFF
--- a/modules/tabs/scss/_tabs.scss
+++ b/modules/tabs/scss/_tabs.scss
@@ -134,6 +134,6 @@
     }
 
     // Tabs: pane
-    .tabs__pane {
+    .tabs--separate .tabs__pane {
         display: none;
     }

--- a/modules/tabs/views/tabs-panes.html
+++ b/modules/tabs/views/tabs-panes.html
@@ -1,3 +1,3 @@
-<div class="tabs">
+<div class="tabs tabs--separate">
     <div class="tabs__panes" ng-transclude></div>
 </div>


### PR DESCRIPTION
this display issue was introduced by 20bfe180b988c84b0aef73785b3e752ed0d620cf

Fixes #583 

## Test scenario
- Go to the tabs component page (`/components/tabs`) and check that all first tabs are displayed as expected
- Go to any documentation page and toggle the code samples (via the < > icon)
--> check that the tabs panes are displayed ok