### PR TITLE
fix(lx-choices): dropdown directive wont scroll top on choice change

### DIFF
--- a/modules/dropdown/js/dropdown_service.js
+++ b/modules/dropdown/js/dropdown_service.js
@@ -15,6 +15,7 @@
 
         service.close = close;
         service.closeActiveDropdown = closeActiveDropdown;
+        service.handleScrollAfterRecompilation = handleScrollAfterRecompilation;
         service.open = open;
         service.isOpen = isOpen;
         service.registerActiveDropdownUuid = registerActiveDropdownUuid;
@@ -39,6 +40,24 @@
                 {
                     documentClick: true,
                     uuid: activeDropdownUuid
+                });
+            }
+        }
+
+        function handleScrollAfterRecompilation(evt)
+        {
+            var dropdownElement;
+            var registeredScrollTop = 0;
+
+            dropdownElement = angular.element(evt.target).closest('.lx-select-choices.dropdown-menu--is-open')[0];
+
+            if (angular.isDefined(dropdownElement)) {
+                registeredScrollTop = dropdownElement.scrollTop;
+            }
+
+            if (registeredScrollTop > 0) {
+                $timeout(function waitForDigestCycle() {
+                    dropdownElement.scrollTop = registeredScrollTop;
                 });
             }
         }

--- a/modules/select/js/select_directive.js
+++ b/modules/select/js/select_directive.js
@@ -839,8 +839,10 @@
             selectedTemplate = _selectedTemplate;
         }
 
-        function select(_choice)
+        function select(_choice, cb)
         {
+            cb = cb || angular.noop;
+
             if (lxSelect.multiple && angular.isUndefined(lxSelect.ngModel))
             {
                 lxSelect.ngModel = [];
@@ -893,6 +895,10 @@
                     $element.find('.lx-select-selected__filter input').focus();
                 }
             }
+
+            if (angular.isFunction(cb)) {
+                cb();
+            }
         }
 
         /**
@@ -906,10 +912,24 @@
                 evt.stopPropagation();
             }
 
+            var areChoicesOpened = lxSelect.areChoicesOpened();
+
             if (lxSelect.multiple && isSelected(choice)) {
-                lxSelect.unselect(choice);
+                lxSelect.unselect(choice, function onUnselect() {
+                    if (areChoicesOpened) {
+                        $timeout(function onTimeout() {
+                            LxDropdownService.handleScrollAfterRecompilation(evt);
+                        })
+                    }
+                });
             } else {
-                lxSelect.select(choice);
+                lxSelect.select(choice, function onUnselect() {
+                    if (areChoicesOpened) {
+                        $timeout(function onTimeout() {
+                            LxDropdownService.handleScrollAfterRecompilation(evt);
+                        })
+                    }
+                });
             }
 
             if (lxSelect.autocomplete) {
@@ -966,8 +986,10 @@
             _openPane(parentIndex, key, false);
         }
 
-        function unselect(_choice)
+        function unselect(_choice, cb)
         {
+            cb = cb || angular.noop;
+
             if (angular.isDefined(lxSelect.selectionToModel))
             {
                 lxSelect.selectionToModel(
@@ -1006,6 +1028,10 @@
                     (lxSelect.ngModel.length === 0 || lxSelect.multiple)) {
                     $element.find('.lx-select-selected__filter input').focus();
                 }
+            }
+
+            if (angular.isFunction(cb)) {
+                cb();
             }
         }
 


### PR DESCRIPTION
## General summary

Fixes the dropdown directive scrollTop reset bug when a choice is toggled from a scrollable multiple select.

When a choice was toggled, the `ng-repeat` which was rendered in the dropdown directive was recompiled each time a change was made il the attached `ng-model`. This was causing the `scrollTop` reset on the dropdown element.