### PR TITLE
fix(lx-select): fix highlight in 'pane' view mode

### DIFF
--- a/modules/select/js/select_directive.js
+++ b/modules/select/js/select_directive.js
@@ -596,6 +596,7 @@
             };
 
             var interpolatedChoice = $interpolate(choiceTemplate)(choiceScope);
+            interpolatedChoice = '<span>' + interpolatedChoice + '</span>';
             return $sce.trustAsHtml((lxSelect.matchingPaths) ?
                 $filter('lxHighlight')(interpolatedChoice, lxSelect.filterModel, true) : interpolatedChoice
             );


### PR DESCRIPTION
# Reproduct bug

https://ui.lumapps.com/components/select

Type `age` in multipane select and see result `Male humans > middle aged` without space beetween `middle` and `aged`