### PR TITLE
fix(progress): change from ng-class to class ternary

### DIFF
--- a/modules/progress/js/progress_directive.js
+++ b/modules/progress/js/progress_directive.js
@@ -73,6 +73,7 @@
         {
             lxProgress.lxDiameter = angular.isDefined(lxProgress.lxDiameter) ? lxProgress.lxDiameter : 100;
             lxProgress.lxColor = angular.isDefined(lxProgress.lxColor) ? lxProgress.lxColor : 'primary';
+            lxProgress.lxClass = angular.isDefined(lxProgress.lxValue) ? 'progress-container--determinate' : 'progress-container--indeterminate';
         }
     }
 })();

--- a/modules/progress/views/progress.html
+++ b/modules/progress/views/progress.html
@@ -1,4 +1,4 @@
-<div class="progress-container progress-container--{{ lxProgress.lxType }} progress-container--{{ lxProgress.lxColor }} progress-container--{{ lxProgress.lxValue ? 'determinate' : 'indeterminate' }}">
+<div class="progress-container progress-container--{{ lxProgress.lxType }} progress-container--{{ lxProgress.lxColor }} {{ lxProgress.lxClass }}">
     <div class="progress-circular"
          ng-if="lxProgress.lxType === 'circular'"
          ng-style="lxProgress.getProgressDiameter()">

--- a/modules/progress/views/progress.html
+++ b/modules/progress/views/progress.html
@@ -1,6 +1,4 @@
-<div class="progress-container progress-container--{{ lxProgress.lxType }} progress-container--{{ lxProgress.lxColor }}"
-     ng-class="{ 'progress-container--determinate': lxProgress.lxValue,
-                 'progress-container--indeterminate': !lxProgress.lxValue }">
+<div class="progress-container progress-container--{{ lxProgress.lxType }} progress-container--{{ lxProgress.lxColor }} progress-container--{{ lxProgress.lxValue ? 'determinate' : 'indeterminate' }}">
     <div class="progress-circular"
          ng-if="lxProgress.lxType === 'circular'"
          ng-style="lxProgress.getProgressDiameter()">


### PR DESCRIPTION
<img width="1205" alt="screen shot 2018-04-08 at 7 42 22 pm" src="https://user-images.githubusercontent.com/11836769/38471239-17ec7618-3b66-11e8-8367-cd301799ca9d.png">

**Browsers**
Chromium v67.0.3387.0
Safari v11.0.2

The ScreenShot above shows `div.progress-container--indeterminate` class not activated. So I switched to using `?:`operator, which activates `? 'determinate' : 'indeterminate'` depending on the `lx-value` value, set as an attribute by the user.

<img width="1198" alt="screen shot 2018-04-08 at 8 02 02 pm" src="https://user-images.githubusercontent.com/11836769/38471461-49ab8b8c-3b69-11e8-8a81-b8315a8ac56a.png">

The ScreenShot above shows `div.progress-container--indeterminate` activated and running fine.

**Note**: Bug and Fixes on both browsers listed above.