### PR TITLE
fix(dropdown): fix closing with iOS

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -145,7 +145,11 @@
 
         function closeDropdownMenu()
         {
-            $document.off('click', onDocumentClick);
+            if ('ontouchstart' in window) {
+                $document.off('touchstart', onDocumentClick);
+            } else {
+                $document.off('click', onDocumentClick);
+            }
 
             $rootScope.$broadcast('lx-dropdown__close-start', $element.attr('id'));
 
@@ -381,8 +385,12 @@
 
         function openDropdownMenu()
         {
-            $document.on('click', onDocumentClick);
-
+            if ('ontouchstart' in window) {
+                $document.on('touchstart', onDocumentClick);
+            } else {
+                $document.on('click', onDocumentClick);
+            }
+            
             $rootScope.$broadcast('lx-dropdown__open-start', $element.attr('id'));
 
             lxDropdown.isOpen = true;


### PR DESCRIPTION
With iOS, the dropdown can't be closed.

This fix use 'ontouchstart' event when touch event is available instead of the `click` event.

**Test**
- try to open/close a dropdown with iOS