### PR TITLE
fix(dropdown): fix dropdown with touch events

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -145,7 +145,7 @@
 
         function closeDropdownMenu()
         {
-            $document.off('click touchstart', onDocumentClick);
+            $document.off('click touchend', onDocumentClick);
 
             $rootScope.$broadcast('lx-dropdown__close-start', $element.attr('id'));
 
@@ -376,13 +376,19 @@
         }
 
         function onDocumentClick() {
-            LxDropdownService.close(lxDropdown.uuid, true);
+            $timeout(function nextDigest() {
+                LxDropdownService.close(lxDropdown.uuid, true);
+            })
         }
 
         function openDropdownMenu()
         {
-            $document.on('click touchstart', onDocumentClick);
-            
+            $document.on('click touchend', onDocumentClick);
+
+            $document.on('touchmove', function onTouchMove(evt) {
+                $document.off('touchend', onDocumentClick);
+            });
+
             $rootScope.$broadcast('lx-dropdown__open-start', $element.attr('id'));
 
             lxDropdown.isOpen = true;


### PR DESCRIPTION
Fix the dropdown in responsive mode 

### Test Scenario : 
1. Open Dropdown component page
2. Change view mode for responsive mode (Nexus 5x for example)
3. Try to open a dropdown, scroll in dropdown menu
4. Click on a link in the dropdown menu, be sure the click/touch event is not intercept by the element dehind the menu link you've just clicked.