### PR TITLE
fix(fab): fix behavior of triggerOnClick attribute is set to false

### DIFF
--- a/modules/fab/js/fab_directive.js
+++ b/modules/fab/js/fab_directive.js
@@ -31,7 +31,7 @@
 
             attrs.$observe('lxTriggerOnClick', function(isTriggeredOnClick)
             {
-                ctrl.setFabTriggerMethod(isTriggeredOnClick);
+                ctrl.setFabTriggerMethod(scope.$eval(isTriggeredOnClick));
             });
         }
     }


### PR DESCRIPTION
Fix the behavior on the trigger-on-click if attribute is set to false.

### Test scenarios:
1. Edit basic.html of FAB Button demo to add the attribute `trigger-on-click="false"`
2. Refresh the FAB page
3. hover the FAB button you've just edit, the fab actions shoud appear