### PR TITLE
fix(dropdown): update logic for ios

### DIFF
--- a/core/js/utils/utils_service.js
+++ b/core/js/utils/utils_service.js
@@ -95,9 +95,7 @@
             if (hasVerticalScrollbar)
             {
               angular.element('body').css({
-                position: 'fixed',
-                width: '100%',
-                top: -viewportTop + 'px'
+                overflow: 'hidden',
               });
             }
 

--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -394,15 +394,10 @@
             lxDropdown.isOpen = true;
 
             LxDepthService.register();
-
-            if (!lxDropdown.hover) {
-                scrollMask
-                    .css('z-index', LxDepthService.getDepth())
-                    .appendTo('body');
-                scrollMask.on('wheel', function preventDefault(e) {
-                    e.preventDefault();
-                });
-            }
+            
+            scrollMask.css('z-index', LxDepthService.getDepth()).appendTo('body');
+            
+            angular.element(scrollMask).on('click wheel touchmove ontouchstart', closeDropdownMenu);
 
             angular.element(window).on('resize', initDropdownPosition);
 

--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -397,7 +397,8 @@
             
             scrollMask.css('z-index', LxDepthService.getDepth()).appendTo('body');
             
-            angular.element(scrollMask).on('click wheel touchmove ontouchstart', closeDropdownMenu);
+            // An action outside the dropdown triggers the close function.
+            scrollMask.on('click wheel touchmove ontouchstart', closeDropdownMenu);
 
             angular.element(window).on('resize', initDropdownPosition);
 


### PR DESCRIPTION
With iOS, dropdown position can be have a wrong position because when a dropdown is open the body becomes fixed.

I remove this fixed and I close the dropdown when we scroll or click outside the dropdown.