### PR TITLE
fix(progress): prevent animation wobble

### DIFF
--- a/modules/progress/js/progress_directive.js
+++ b/modules/progress/js/progress_directive.js
@@ -33,8 +33,6 @@
         lxProgress.getLinearProgressValue = getLinearProgressValue;
         lxProgress.getProgressDiameter = getProgressDiameter;
 
-        init();
-
         ////////////
 
         function getCircularProgressValue()
@@ -75,5 +73,7 @@
             lxProgress.lxColor = angular.isDefined(lxProgress.lxColor) ? lxProgress.lxColor : 'primary';
             lxProgress.lxClass = angular.isDefined(lxProgress.lxValue) ? 'progress-container--determinate' : 'progress-container--indeterminate';
         }
+
+        this.$onInit = init;
     }
 })();

--- a/modules/progress/scss/_progress.scss
+++ b/modules/progress/scss/_progress.scss
@@ -76,7 +76,10 @@
         @include position(absolute, 0 0 0 0);
         @include size(100%);
         margin: auto;
+    }
 
+    // Progress ciruclar: g
+    .progress-ciruclar__g {
         .progress-container--determinate & {
             @include transform(rotate(-90deg));
         }

--- a/modules/progress/scss/_progress.scss
+++ b/modules/progress/scss/_progress.scss
@@ -86,7 +86,6 @@
 
         .progress-container--indeterminate & {
             @include animation(lx-progress-circular-rotate 2s linear infinite);
-            @include transform-origin(center center);
         }
     }
 

--- a/modules/progress/scss/_progress.scss
+++ b/modules/progress/scss/_progress.scss
@@ -70,7 +70,7 @@
         padding-top: 100%;
     }
 }
-    
+
     // Progress circular: svg
     .progress-circular__svg {
         @include position(absolute, 0 0 0 0);
@@ -79,7 +79,7 @@
     }
 
     // Progress ciruclar: g
-    .progress-ciruclar__g {
+    .progress-circular__g {
         .progress-container--determinate & {
             @include transform(rotate(-90deg));
         }

--- a/modules/progress/views/progress.html
+++ b/modules/progress/views/progress.html
@@ -3,7 +3,9 @@
          ng-if="lxProgress.lxType === 'circular'"
          ng-style="lxProgress.getProgressDiameter()">
         <svg class="progress-circular__svg">
-            <circle class="progress-circular__path" cx="50" cy="50" r="20" fill="none" stroke-width="4" stroke-miterlimit="10" ng-style="lxProgress.getCircularProgressValue()">
+            <g class="progress-circular__g">
+                <circle class="progress-circular__path" cx="50" cy="50" r="20" fill="none" stroke-width="4" stroke-miterlimit="10" ng-style="lxProgress.getCircularProgressValue()"></circle>
+            </g>
         </svg>
     </div>
 

--- a/modules/progress/views/progress.html
+++ b/modules/progress/views/progress.html
@@ -3,8 +3,10 @@
          ng-if="lxProgress.lxType === 'circular'"
          ng-style="lxProgress.getProgressDiameter()">
         <svg class="progress-circular__svg">
-            <g class="progress-circular__g">
-                <circle class="progress-circular__path" cx="50" cy="50" r="20" fill="none" stroke-width="4" stroke-miterlimit="10" ng-style="lxProgress.getCircularProgressValue()"></circle>
+            <g transform="translate(50 50)">
+                <g class="progress-circular__g">
+                    <circle class="progress-circular__path" cx="0" cy="0" r="20" fill="none" stroke-width="4" stroke-miterlimit="10" ng-style="lxProgress.getCircularProgressValue()"></circle>
+                </g>
             </g>
         </svg>
     </div>


### PR DESCRIPTION
## General summary
Chrome (Version 67.0.3396.87 (Official Build) (64-bit)) has rendering artifacts when SVG elements are animated in an also animated HTML container when the viewport zoom is other than 100%. This makes the circular `lx-progress` component wobble.

The fix consists of moving the animation behavior from the `svg` element (which is an HTML node) to a `g` (which is an SVG node). With all the animation happening in the `svg` land, the Chrome rendering pipeline works better.

### Expected behavior
![non-wobbly](https://user-images.githubusercontent.com/297345/42081745-83928a1e-7b86-11e8-9755-901db7d7760a.gif)

### Current behavior
![wobbly](https://user-images.githubusercontent.com/297345/42081748-872621e0-7b86-11e8-9ba4-3e156bea48ff.gif)

### Steps to reproduce
1. Go to the [`lx-progress` demo](https://ui.lumapps.com/components/progress).
2. Click on the `toggle circular progress` button.
3. Zoom-out and resize the window until you see that the `lx-progress` wobbles.
