### PR TITLE
fix(dropdown): add mask only if hover is false

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -161,7 +161,7 @@
             var velocityProperties;
             var velocityEasing;
 
-            if (scrollMask) {
+            if (!lxDropdown.hover && angular.isDefined(scrollMask)) {
                 scrollMask.remove();
             }
             if (angular.isFunction(enableBodyScroll)) {
@@ -395,10 +395,12 @@
 
             LxDepthService.register();
             
-            scrollMask.css('z-index', LxDepthService.getDepth()).appendTo('body');
+            if (!lxDropdown.hover) {
+                scrollMask.css('z-index', LxDepthService.getDepth()).appendTo('body');
             
-            // An action outside the dropdown triggers the close function.
-            scrollMask.on('click wheel touchmove ontouchstart', closeDropdownMenu);
+                // An action outside the dropdown triggers the close function.
+                scrollMask.on('click wheel touchmove ontouchstart', closeDropdownMenu);
+            }
 
             angular.element(window).on('resize', initDropdownPosition);
 


### PR DESCRIPTION
When we open a dropdown, the mask is useful only if we open the dropdown by a click.
If the directive has a `lx-hover = true` the dropdown will been closed when the dropdown loses its hover state.