### PR TITLE
docs: fix css color names display

### DIFF
--- a/demo/includes/css/color/palette.html
+++ b/demo/includes/css/color/palette.html
@@ -148,7 +148,9 @@
             <span class="color__variable">$purple-A700</span>
         </div>
     </div>
+</div>
 
+<div class="p++" flex-container="row" flex-gutter="24">
     <!-- Deep purple Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-deep-purple-500">
@@ -198,9 +200,7 @@
             <span class="color__variable">$deep-purple-A700</span>
         </div>
     </div>
-</div>
 
-<div class="p++" flex-container="row" flex-gutter="24">
     <!-- Indigo Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-indigo-500">
@@ -300,7 +300,9 @@
             <span class="color__variable">$blue-A700</span>
         </div>
     </div>
+</div>
 
+<div class="p++" flex-container="row" flex-gutter="24">
     <!-- Light Blue Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-light-blue-500">
@@ -602,7 +604,9 @@
             <span class="color__variable color__variable--black">$lime-A700</span>
         </div>
     </div>
+</div>
 
+<div class="p++" flex-container="row" flex-gutter="24">
     <!-- Yellow Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-yellow-500">
@@ -652,9 +656,7 @@
             <span class="color__variable color__variable--black">$yellow-A700</span>
         </div>
     </div>
-</div>
 
-<div class="p++" flex-container="row" flex-gutter="24">
     <!-- Amber Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-amber-500">
@@ -754,7 +756,9 @@
             <span class="color__variable">$orange-A700</span>
         </div>
     </div>
+</div>
 
+<div class="p++" flex-container="row" flex-gutter="24">
     <!-- Deep Orange Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-deep-orange-500">
@@ -842,9 +846,7 @@
             <span class="color__variable">$brown-900</span>
         </div>
     </div>
-</div>
 
-<div class="p++" flex-container="row" flex-gutter="24">
     <!-- Grey Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-grey-500">
@@ -882,7 +884,9 @@
             <span class="color__variable">$grey-900</span>
         </div>
     </div>
+</div>
 
+<div class="p++" flex-container="row" flex-gutter="24">
     <!-- Blue Grey Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-blue-grey-500">
@@ -928,16 +932,16 @@
             <span class="color__variable">$black</span>
         </div>
         <div class="bgc-black-1">
-            <span class="color__variable">$black-1, alpha : 87%</span>
+            <span class="color__variable">$black-1, alpha: 87%</span>
         </div>
         <div class="bgc-black-2">
-            <span class="color__variable">$black-2, alpha : 54%</span>
+            <span class="color__variable">$black-2, alpha: 54%</span>
         </div>
         <div class="bgc-black-3">
-            <span class="color__variable color__variable--black">$black-3, alpha : 38%</span>
+            <span class="color__variable color__variable--black">$black-3, alpha: 38%</span>
         </div>
         <div class="bgc-black-4">
-            <span class="color__variable color__variable--black">$black-4, alpha : 12%</span>
+            <span class="color__variable color__variable--black">$black-4, alpha: 12%</span>
         </div>
     </div>
 
@@ -948,16 +952,16 @@
             <span class="color__variable color__variable--black">$white</span>
         </div>
         <div class="bgc-white-1">
-            <span class="color__variable color__variable--black">$white-1, alpha : 100%</span>
+            <span class="color__variable color__variable--black">$white-1, alpha: 100%</span>
         </div>
         <div class="bgc-white-2">
-            <span class="color__variable color__variable--black">$white-2, alpha : 70%</span>
+            <span class="color__variable color__variable--black">$white-2, alpha: 70%</span>
         </div>
         <div class="bgc-white-3">
-            <span class="color__variable color__variable--black">$white-3, alpha : 30%</span>
+            <span class="color__variable color__variable--black">$white-3, alpha: 30%</span>
         </div>
         <div class="bgc-white-4">
-            <span class="color__variable color__variable--black">$white-4, alpha : 12%</span>
+            <span class="color__variable color__variable--black">$white-4, alpha: 12%</span>
         </div>
     </div>
 </div>

--- a/demo/includes/css/color/palette.html
+++ b/demo/includes/css/color/palette.html
@@ -48,7 +48,7 @@
             <span class="color__variable">$red-A700</span>
         </div>
     </div>
- 
+
     <!-- Pink Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-pink-500">
@@ -98,7 +98,7 @@
             <span class="color__variable">$pink-A700</span>
         </div>
     </div>
- 
+
     <!-- Purple Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-purple-500">
@@ -148,7 +148,7 @@
             <span class="color__variable">$purple-A700</span>
         </div>
     </div>
- 
+
     <!-- Deep purple Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-deep-purple-500">
@@ -199,7 +199,7 @@
         </div>
     </div>
 </div>
- 
+
 <div class="p++" flex-container="row" flex-gutter="24">
     <!-- Indigo Color -->
     <div class="color" flex-item>
@@ -250,7 +250,7 @@
             <span class="color__variable">$indigo-A700</span>
         </div>
     </div>
- 
+
     <!-- Blue Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-blue-500">
@@ -300,7 +300,7 @@
             <span class="color__variable">$blue-A700</span>
         </div>
     </div>
- 
+
     <!-- Light Blue Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-light-blue-500">
@@ -350,7 +350,7 @@
             <span class="color__variable">$light-blue-A700</span>
         </div>
     </div>
- 
+
     <!-- Cyan Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-cyan-500">
@@ -400,7 +400,7 @@
             <span class="color__variable">$cyan-A700</span>
         </div>
     </div>
- 
+
     <!-- Teal Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-teal-500">
@@ -451,7 +451,7 @@
         </div>
     </div>
 </div>
- 
+
 <div class="p++" flex-container="row" flex-gutter="24">
     <!-- Green Color -->
     <div class="color" flex-item>
@@ -502,7 +502,7 @@
             <span class="color__variable">$green-A700</span>
         </div>
     </div>
- 
+
     <!-- Light Green Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-light-green-500">
@@ -552,7 +552,7 @@
             <span class="color__variable color__variable--black">$light-green-A700</span>
         </div>
     </div>
- 
+
     <!-- Lime Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-lime-500">
@@ -602,7 +602,7 @@
             <span class="color__variable color__variable--black">$lime-A700</span>
         </div>
     </div>
- 
+
     <!-- Yellow Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-yellow-500">
@@ -653,7 +653,7 @@
         </div>
     </div>
 </div>
- 
+
 <div class="p++" flex-container="row" flex-gutter="24">
     <!-- Amber Color -->
     <div class="color" flex-item>
@@ -704,7 +704,7 @@
             <span class="color__variable">$amber-A700</span>
         </div>
     </div>
- 
+
     <!-- Orange  Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-orange-500">
@@ -754,7 +754,7 @@
             <span class="color__variable">$orange-A700</span>
         </div>
     </div>
- 
+
     <!-- Deep Orange Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-deep-orange-500">
@@ -804,7 +804,7 @@
             <span class="color__variable">$deep-orange-A700</span>
         </div>
     </div>
- 
+
     <!-- Brown Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-brown-500">
@@ -843,7 +843,7 @@
         </div>
     </div>
 </div>
- 
+
 <div class="p++" flex-container="row" flex-gutter="24">
     <!-- Grey Color -->
     <div class="color" flex-item>
@@ -882,7 +882,7 @@
             <span class="color__variable">$grey-900</span>
         </div>
     </div>
- 
+
     <!-- Blue Grey Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-blue-grey-500">
@@ -920,7 +920,8 @@
             <span class="color__variable">$blue-grey-900</span>
         </div>
     </div>
- 
+
+    <!-- Black Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-black">
             <span class="color__title">Black</span>
@@ -939,7 +940,8 @@
             <span class="color__variable color__variable--black">$black-4, alpha : 12%</span>
         </div>
     </div>
- 
+
+    <!-- White Color -->
     <div class="color" flex-item>
         <div class="color__main bgc-white">
             <span class="color__title color__variable--black">White</span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1215056/46360385-8f227300-c66b-11e8-91ef-7f92a510f0f2.png)

Changed the number of items per row and boom, it's fixed ;)

It's even on par with the Material Design docs on https://material.io/design/color/the-color-system.html#tools-for-picking-colors :D