### PR TITLE
fix(dev-server): fix the path to launch the dev server

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python $APPENGINE/dev_appserver.py --host 0.0.0.0 --port 8888 build/
+python $APPENGINE/dev_appserver.py --host 0.0.0.0 --port 8888 ${PWD}/build/


### PR DESCRIPTION
Since the latest AppEngine update, relative path doesn't work anymore.