### PR TITLE
feat(text-field): add a new `hasPlaceholder` param

### DIFF
--- a/modules/text-field/demo/includes/basic.html
+++ b/modules/text-field/demo/includes/basic.html
@@ -2,18 +2,22 @@
     <lx-text-field lx-label="Company" lx-allow-clear="true">
         <input type="text" ng-model="vm.textFields.floating.company">
     </lx-text-field>
- 
+
     <div flex-container="row" flex-gutter="24">
         <div flex-item>
             <lx-text-field lx-label="First name">
                 <input type="text" ng-model="vm.textFields.floating.firstName">
             </lx-text-field>
         </div>
- 
+
         <div flex-item>
             <lx-text-field lx-label="Last name">
                 <input type="text" ng-model="vm.textFields.floating.lastName">
             </lx-text-field>
         </div>
     </div>
+
+    <lx-text-field lx-label="Field with placeholder" lx-has-placeholder="true">
+        <input type="text" placeholder="Placeholder" ng-model="vm.textFields.floating.empty">
+    </lx-text-field>
 </div>

--- a/modules/text-field/demo/js/demo-text-field_controller.js
+++ b/modules/text-field/demo/js/demo-text-field_controller.js
@@ -17,7 +17,8 @@
             {
                 company: 'LumApps',
                 firstName: 'Matthias',
-                lastName: 'Manoukian'
+                lastName: 'Manoukian',
+                empty: ''
             },
             fixed:
             {

--- a/modules/text-field/js/text-field_directive.js
+++ b/modules/text-field/js/text-field_directive.js
@@ -22,6 +22,7 @@
                 icon: '@?lxIcon',
                 label: '@lxLabel',
                 ngDisabled: '=?',
+                hasPlaceholder: '=?lxHasPlaceholder',
                 theme: '@?lxTheme',
                 valid: '=?lxValid'
             },

--- a/modules/text-field/views/text-field.html
+++ b/modules/text-field/views/text-field.html
@@ -1,9 +1,9 @@
 <div class="text-field"
      ng-class="{ 'text-field--error': lxTextField.error,
-                 'text-field--fixed-label': lxTextField.fixedLabel,
+                 'text-field--fixed-label': lxTextField.fixedLabel && !lxTextField.hasPlaceholder,
                  'text-field--has-icon': lxTextField.icon,
                  'text-field--has-value': lxTextField.hasValue(),
-                 'text-field--is-active': lxTextField.isActive,
+                 'text-field--is-active': lxTextField.isActive || lxTextField.hasPlaceholder,
                  'text-field--is-disabled': lxTextField.ngDisabled,
                  'text-field--is-focus': lxTextField.isFocus,
                  'text-field--theme-light': !lxTextField.theme || lxTextField.theme === 'light',


### PR DESCRIPTION
This param allow to have a placeholder on the transcluded input type.
This way, the label always stays on top of the field.
This param is not compatible with the `fixedLabel` param