### PR TITLE
fix: clear cross in text field in ie11

### DIFF
--- a/core/scss/generic/_generic.normalize.scss
+++ b/core/scss/generic/_generic.normalize.scss
@@ -395,6 +395,12 @@ textarea {
   font: inherit; /* 2 */
 }
 
+/**
+* Remove the clear cross when present in ie11 in text fields  
+*
+*/
+[type="text"]::-ms-clear {  display: none; width : 0; height: 0; }
+
 /* Interactive
    ========================================================================== */
 


### PR DESCRIPTION
Fix the issue in ie11 described in lum-1900 that was causing a big cross left to the normal lumx clear-cross to appear.

![vigs-search-issue](https://user-images.githubusercontent.com/45166587/55006892-c3ee0200-4fde-11e9-9aa4-bdfb73135c90.png)
