### PR TITLE
feat(infinite-scroll-loader): move to correct position

### DIFF
--- a/modules/select/scss/_select.scss
+++ b/modules/select/scss/_select.scss
@@ -488,11 +488,6 @@
         }
     }
 
-    // Select choices: loader
-    .lx-select-choices--default-style .lx-select-choices__loader {
-        @include position(absolute, 0 0 null 0);
-    }
-
     .lx-select-choices--multi-panes {
         width: auto !important;
         overflow: hidden !important;

--- a/modules/select/views/select-choices.html
+++ b/modules/select/views/select-choices.html
@@ -6,10 +6,6 @@
                               'lx-select-choices--list': lxSelectChoices.parentCtrl.choicesViewMode === 'list',
                               'lx-select-choices--multi-panes': lxSelectChoices.parentCtrl.choicesViewMode === 'panes' }">
     <ul ng-if="::lxSelectChoices.parentCtrl.choicesViewMode === 'list'">
-        <li class="lx-select-choices__loader" ng-if="lxSelectChoices.parentCtrl.loading">
-            <lx-progress lx-type="linear" lx-color="primary"></lx-progress>
-        </li>
-
         <li class="lx-select-choices__filter" ng-if="::lxSelectChoices.parentCtrl.displayFilter && !lxSelectChoices.parentCtrl.autocomplete">
             <lx-search-filter lx-dropdown-filter>
                 <input type="text" ng-model="lxSelectChoices.parentCtrl.filterModel" ng-change="lxSelectChoices.parentCtrl.updateFilter()">
@@ -83,4 +79,5 @@
         </div>
     </div>
 
+    <lx-progress lx-type="linear" lx-color="primary" ng-if="lxSelectChoices.parentCtrl.loading"></lx-progress>
 </lx-dropdown-menu>


### PR DESCRIPTION
Removes the infinite scroll loader from the top of the dropdown so that we can see it correctly when scrolling.