### PR TITLE
fix(dropdown): fix dropdown visibility when closed

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -467,7 +467,9 @@
                         width: 0,
                         height: 0,
                         opacity: 1,
-                        overflow: 'hidden'
+                        overflow: 'hidden',
+                        visibility: 'visible',
+
                     });
 
                     dropdownMenu.find('.dropdown-menu__content').css(
@@ -519,7 +521,8 @@
                 {
                     dropdownMenu.css(
                     {
-                        height: dropdownMenuHeight
+                        height: dropdownMenuHeight,
+                        visibility: 'visible',
                     });
 
                     dropdownMenu.velocity(
@@ -540,7 +543,8 @@
                 {
                     dropdownMenu.css(
                     {
-                        opacity: 1
+                        opacity: 1,
+                        visibility: 'visible',
                     });
 
                     $timeout(updateDropdownMenuHeight);

--- a/modules/dropdown/scss/_dropdown.scss
+++ b/modules/dropdown/scss/_dropdown.scss
@@ -28,7 +28,8 @@
     border-radius: $base-round;
     background-color: $white;
     text-align: left;
-    opacity: 0;
+    visibility: hidden;
+    opacity: 0;    
     overflow: auto;
     @include elevation(8);
 


### PR DESCRIPTION
#### Problem
The dropdown menu was only hidden with an opacity: 0, so it remained selectable even when the dropdown menu was closed.

#### Fix 
Added visibility hidden/visible to prevent any events on the dropdown without modifying current behavior (styles, animations, ...)
