### PR TITLE
fix(dropdown): add timeout for ios

### DIFF
--- a/modules/dropdown/js/dropdown_directive.js
+++ b/modules/dropdown/js/dropdown_directive.js
@@ -383,7 +383,7 @@
         function onDocumentClick() {
             $timeout(function nextDigest() {
                 LxDropdownService.close(lxDropdown.uuid, true);
-            })
+            }, 250)
         }
 
         function openDropdownMenu()


### PR DESCRIPTION
Add a timeout to avoid a bug when you click on an item with an action inside a dropdown.